### PR TITLE
Removing :void return type decalration

### DIFF
--- a/pp3/module/Application/src/Application/Entity/Base/Verification.php
+++ b/pp3/module/Application/src/Application/Entity/Base/Verification.php
@@ -100,7 +100,7 @@ class Verification {
         return $this->nbVersionPluginVersion;
     }
 
-    function setNbVersionPluginVersion($nbVersionPluginVersion): void {
+    function setNbVersionPluginVersion($nbVersionPluginVersion) {
         $this->nbVersionPluginVersion = $nbVersionPluginVersion;
     }
 }


### PR DESCRIPTION
Removing unsupported PHP syntax (this return type is available from PHP 7.1 IIRC, while 7.0.1 on server) 