### PR TITLE
Fetch SHA1 digest from maven central when version is created and show for verification

### DIFF
--- a/pp3/config/pp3.sql
+++ b/pp3/config/pp3.sql
@@ -128,6 +128,14 @@ CREATE TABLE IF NOT EXISTS `verification_request` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
 
+CREATE TABLE IF NOT EXISTS `plugin_version_digest` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `plugin_version_id` int(11) NOT NULL REFERENCES plugin_version(id),
+  `algorithm` varchar(50) NOT NULL,
+  `value` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci;
+
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/pp3/module/Application/config/module.config.php.dist
+++ b/pp3/module/Application/config/module.config.php.dist
@@ -33,7 +33,7 @@ return array(
         'mavenRepoUrl' => 'https://repo1.maven.org/maven2/',
         'catalogSavepath' => '/home/honza/checkout/pp3/public/data',
         'catalogUrlPath' => 'http://localhost/checkout/pp3/public/data',    
-        'dtdPath' => 'http://localhost/checkout/pp3/public/data/autoupdate-catalog-2_6.dtd'
+        'dtdPath' => 'http://localhost/checkout/pp3/public/dtd/autoupdate-catalog-2_8.dtd'
     ),
     'loginConfig' => array (
         array(

--- a/pp3/module/Application/src/Application/Controller/PluginController.php
+++ b/pp3/module/Application/src/Application/Controller/PluginController.php
@@ -163,23 +163,8 @@ class PluginController extends AuthenticatedController {
                 $plugin->setHomepage($validatedData['homepage']);
                 $plugin->setAddedAt(new \DateTime('now'));
                 $plugin->setLastUpdatedAt(new \DateTime('now'));
-                // save also versions
-                if (!empty($plugin->tmpVersions)) {
-                    foreach($plugin->tmpVersions as $vers) {
-                        try {
-                            $v = new PluginVersion();
-                            $v->setVersion($vers);
-                            $v->setPlugin($plugin);
-                            $v->setupUrl();
-                            $plugin->addVersion($v);
-                        } catch (\Exception $e) {
-                            $this->flashMessenger()->setNamespace('error')->addMessage($e->getMessage());                
-                        }
-                    }
-                }
                 // categ
                 $plugin->removeCategories();
-                $this->_pluginRepository->persist($plugin);
                 $cat = $this->_categoryRepository->find($validatedData['category']);
                 if ($cat) {
                     $plugin->addCategory($cat);

--- a/pp3/module/Application/src/Application/Entity/Base/PluginVersion.php
+++ b/pp3/module/Application/src/Application/Entity/Base/PluginVersion.php
@@ -22,6 +22,7 @@ namespace Application\Entity\Base;
 
 use Doctrine\ORM\Mapping as ORM;
 use Application\Entity\Plugin;
+use Application\Entity\PluginVersionDigest;
 use Application\Entity\NbVersionPluginVersion;
 use Doctrine\Common\Collections\ArrayCollection;
 
@@ -57,8 +58,14 @@ class PluginVersion {
      */
     protected $plugin;
 
+    /**
+     *  @ORM\OneToMany(targetEntity="PluginVersionDigest", mappedBy="pluginVersion", cascade={"persist", "remove"})
+     */
+    protected $digests;
+
     public function __construct() {
         $this->nbVersionsPluginVersions = new ArrayCollection();
+        $this->digests = new ArrayCollection();
         return $this;
     }
 
@@ -112,5 +119,9 @@ class PluginVersion {
     
     public function getNbVersionsPluginVersions() {
         return $this->nbVersionsPluginVersions;
+    }
+
+    public function getDigests() {
+        return $this->digests;
     }
 }

--- a/pp3/module/Application/src/Application/Entity/Base/PluginVersionDigest.php
+++ b/pp3/module/Application/src/Application/Entity/Base/PluginVersionDigest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Application\Entity\Base;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class PluginVersionDigest {
+
+     /**
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Column(type="integer")
+     */
+    protected $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="PluginVersion", inversedBy="nbVersionsPluginVersions")
+     * @ORM\JoinColumn(name="plugin_version_id", referencedColumnName="id")
+     */
+    protected $pluginVersion;
+
+    /** @ORM\Column(type="string", length=255) */
+    protected $algorithm;
+
+    /** @ORM\Column(type="string", length=255) */
+    protected $value;
+
+    public function __construct() {
+        return $this;
+    }
+
+    function getId() {
+        return $this->id;
+    }
+
+    function setId($id) {
+        $this->id = $id;
+    }
+
+    function getPluginVersion() {
+        return $this->pluginVersion;
+    }
+
+    function setPluginVersion($pluginVersion) {
+        $this->pluginVersion = $pluginVersion;
+    }
+
+    function getAlgorithm() {
+        return $this->algorithm;
+    }
+
+    function setAlgorithm($algorithm) {
+        $this->algorithm = $algorithm;
+    }
+
+    function getValue() {
+        return $this->value;
+    }
+
+    function setValue($value) {
+        $this->value = $value;
+    }
+}

--- a/pp3/module/Application/src/Application/Entity/PluginVersion.php
+++ b/pp3/module/Application/src/Application/Entity/PluginVersion.php
@@ -40,7 +40,15 @@ class PluginVersion extends Base\PluginVersion {
     public function addNbVersion($version) {
         $this->nbVersionsPluginVersions[] = $version;
     }
-    
+
+    public function addDigest($algorithm, $value) {
+        $pvd = new PluginVersionDigest();
+        $pvd->setAlgorithm($algorithm);
+        $pvd->setValue($value);
+        $pvd->setPluginVersion($this);
+        $this->digests[] = $pvd;
+    }
+
     private function _getBinaryExtension($baseUrl) {
         // there could be either .nbm or .jar, so check both
         $extension = array('.nbm', '.jar');

--- a/pp3/module/Application/src/Application/Entity/PluginVersionDigest.php
+++ b/pp3/module/Application/src/Application/Entity/PluginVersionDigest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Application\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="plugin_version_digest")
+ */
+class PluginVersionDigest extends Base\PluginVersionDigest {
+
+}

--- a/pp3/module/Application/src/Application/Pp/Catalog.php
+++ b/pp3/module/Application/src/Application/Pp/Catalog.php
@@ -20,6 +20,8 @@
 
 namespace Application\Pp;
 
+use Applicaton\Entity\PluginVersion;
+
 class Catalog {
     const CATALOG_FILE_NAME = 'catalog.xml';
     const CATALOG_FILE_NAME_EXPERIMENTAL = 'catalog-experimental.xml';
@@ -31,7 +33,10 @@ class Catalog {
     const REQ_ATTRS_MANIFEST_OpenIDE_Module = 'OpenIDE-Module';
     const REQ_ATTRS_MANIFEST_OpenIDE_Module_Name = 'OpenIDE-Module-Name';
     const REQ_ATTRS_MANIFEST_OpenIDE_Module_Specification_Version = 'OpenIDE-Module-Specification-Version';
-    
+
+    const REQ_ATTRS_MESSAGEDIGEST_algorithm = 'algorithm';
+    const REQ_ATTRS_MESSAGEDIGEST_value = 'value';
+
     private $_items;
     private $_version;
     private $_isExperimental;
@@ -48,7 +53,7 @@ class Catalog {
     public function asXml($valiadte = true) {
         $implementation = new \DOMImplementation();
         $dtd = $implementation->createDocumentType('module_updates',
-                                    '-//NetBeans//DTD Autoupdate Catalog 2.6//EN',
+                                    '-//NetBeans//DTD Autoupdate Catalog 2.8//EN',
                                     $this->_dtdPath);
 
         $xml = $implementation->createDocument('', '', $dtd);
@@ -74,6 +79,14 @@ class Catalog {
             $manifestElement->setAttribute('OpenIDE-Module-Long-Description', $item->getPlugin()->getDescription());            
 
             $moduleElement->appendChild($manifestElement);
+
+            foreach($item->getDigests() as $digest) {
+                $messageDigest = $xml->createElement('message_digest');
+                $messageDigest->setAttribute(self::REQ_ATTRS_MESSAGEDIGEST_algorithm, $digest->getAlgorithm());
+                $messageDigest->setAttribute(self::REQ_ATTRS_MESSAGEDIGEST_value, $digest->getValue());
+                $moduleElement->appendChild($messageDigest);
+            }
+
             $modulesEl->appendChild($moduleElement);
         }
         

--- a/pp3/module/Application/view/application/verification/list.phtml
+++ b/pp3/module/Application/view/application/verification/list.phtml
@@ -43,8 +43,15 @@
         $plugin = $pluginVersion->getPlugin();
         echo '<tr>
         <td>
-            <span class="text text-primary" style="font-size:1.2em"><a href="'.$pluginVersion->getUrl().'">'.$plugin->getName().'</a></span>
-        </td>
+            <div class="text text-primary" style="font-size:1.2em"><a href="'.$pluginVersion->getUrl().'">'.$plugin->getName().'</a></div>';
+
+        echo '<table class="table" style="margin: 0">';
+        foreach($pluginVersion->getDigests() as $digest) {
+            printf("<tr><td>%s</td><td>%s</td></tr>\n", $digest->getAlgorithm(), $digest->getValue());
+        }
+        echo '</table>';
+
+        echo '</td>
         <td>
             <span class="badge">'.$pluginVersion->getVersion().'</span> &nbsp; <i class="fas fa-arrow-right"></i> &nbsp;
             <span class="badge">NB '.$nbVersion->getVersion().'</span>

--- a/pp3/public/dtd/autoupdate-catalog-2_8.dtd
+++ b/pp3/public/dtd/autoupdate-catalog-2_8.dtd
@@ -18,10 +18,10 @@
     under the License.
 
 -->
-<!-- -//NetBeans//DTD Autoupdate Catalog 2.6//EN -->
+<!-- -//NetBeans//DTD Autoupdate Catalog 2.8//EN -->
 <!-- XML representation of Autoupdate Modules/Updates Catalog -->
 
-<!ELEMENT module_updates ((notification?, (module_group|module)*, license*)|error)>
+<!ELEMENT module_updates ((notification?, content_description?, (module_group|module)*, license*)|error)>
 <!ATTLIST module_updates timestamp CDATA #REQUIRED>
 
 <!ELEMENT module_group ((module_group|module)*)>
@@ -30,7 +30,10 @@
 <!ELEMENT notification (#PCDATA)>
 <!ATTLIST notification url CDATA #IMPLIED>
 
-<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n) )>
+<!ELEMENT content_description (#PCDATA)>
+<!ATTLIST content_description url CDATA #IMPLIED>
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n), message_digest* )>
 <!ATTLIST module codenamebase CDATA #REQUIRED
                  homepage     CDATA #IMPLIED
                  distribution CDATA #REQUIRED
@@ -41,6 +44,7 @@
                  releasedate  CDATA #IMPLIED
                  global       (true|false) #IMPLIED
                  targetcluster CDATA #IMPLIED
+                 preferredupdate (true|false) #IMPLIED
                  eager (true|false) #IMPLIED
                  autoload (true|false) #IMPLIED>
 
@@ -86,3 +90,7 @@
 <!ELEMENT license (#PCDATA)>
 <!ATTLIST license name CDATA #REQUIRED
                   url  CDATA #IMPLIED>
+
+<!ELEMENT message_digest EMPTY>
+<!ATTLIST message_digest algorithm CDATA #REQUIRED
+                         value     CDATA #REQUIRED>


### PR DESCRIPTION
This PR enables the plugin portal to make use of the extended options
added to the catalog format with version 2.8.

The catalog was enhanced to be able to carry message digest information.
This allows the IDE to verify a download based on the catalog information.

Maven central provides SHA-1 sums - these are downloaded when a new
plugin version is created. At verification time this SHA-1 sum is shown to the
verifier, so that the correct download can be checked. When the catalog
is generated the SHA-1 sum is embedded into the catalog.