### PR TITLE
NETBEANS-3492 Allow admins to edit plugins to NetBeans versions mapping

### DIFF
--- a/pp3/module/Application/src/Application/Controller/PluginVersionController.php
+++ b/pp3/module/Application/src/Application/Controller/PluginVersionController.php
@@ -41,8 +41,9 @@ class PluginVersionController extends AuthenticatedController {
 
     public function editAction() {
         $pvId = $this->params()->fromQuery('id');
+        $search = $this->params()->fromQuery('search');
         $pluginVersion = $this->_pluginVersionRepository->find($pvId);        
-        if (!$pluginVersion || empty($pvId) || !$pluginVersion->getPlugin()->isOwnedBy($this->getAuthenticatedUserId())) {
+        if ((!$pluginVersion || empty($pvId) || !$pluginVersion->getPlugin()->isOwnedBy($this->getAuthenticatedUserId())) && !$this->isAdmin()) {
             return $this->redirect()->toRoute('plugin', array(
                 'action' => 'list'
             ));
@@ -117,18 +118,25 @@ class PluginVersionController extends AuthenticatedController {
         foreach($verifiedNbVersions as $v) {
             $verifiedNbVersionIds[]=$v['id'];
         }
+
+        if ($this->isAdmin() && !empty($search)) {
+            $backUrl = $this->url()->fromRoute('admin', array('action' => 'index'), array('query' => array('search' => $search)));
+        } else {
+            $backUrl = $this->url()->fromRoute('plugin', array('action' => 'list'));
+        }
         
         return new ViewModel([
             'pluginVersion' => $pluginVersion,
             'nbVersions' => $this->_nbVersionRepository->findAll(),
             'verifiedNbVersionIds' => $verifiedNbVersionIds,
+            'return' => $backUrl, 
         ]);
     }
 
     public function deleteAction() {
         $pId = $this->params()->fromQuery('id');
         $pluginVersion = $this->_pluginVersionRepository->find($pId);        
-        if (!$pluginVersion || empty($pId) || !$pluginVersion->getPlugin()->isOwnedBy($this->getAuthenticatedUserId())) {
+        if ((!$pluginVersion || empty($pId) || !$pluginVersion->getPlugin()->isOwnedBy($this->getAuthenticatedUserId())) && !$this->isAdmin()) {
             return $this->redirect()->toRoute('plugin', array(
                 'action' => 'list'
             ));

--- a/pp3/module/Application/src/Application/Controller/VerificationController.php
+++ b/pp3/module/Application/src/Application/Controller/VerificationController.php
@@ -171,7 +171,7 @@ class VerificationController extends AuthenticatedController {
             $bailOut = true;
         }
         $plugin = $nbVersionPluginVersion->getPluginVersion()->getPlugin();
-        if (!$plugin->isOwnedBy($this->getAuthenticatedUserId())) {
+        if (!$plugin->isOwnedBy($this->getAuthenticatedUserId()) && !$this->isAdmin()) {
             $bailOut = true;
         }
         if ($bailOut) {

--- a/pp3/module/Application/view/application/admin/_plugin-listrow.phtml
+++ b/pp3/module/Application/view/application/admin/_plugin-listrow.phtml
@@ -64,6 +64,7 @@ echo '</p>
         <thead>
             <tr>
             <th scope="col" style="width: 170px;">Plugin Version</th>
+            <th scope="col"></th>
             <th scope="col">NB Versions</th>
             <th scope="col">Verifications</th>
             </tr>
@@ -73,6 +74,11 @@ echo '</p>
 foreach ($plugin->getVersions() as $version) {
     echo '<tr>
         <td><span class="badge">'.$version->getVersion().'</span></td>
+        <td>
+            <a class="btn btn-default" href="'.$this->url('plugin-version',array('action'=>'edit'),array('query' => array('id'=>$version->getId(), 'search'=>$_GET['search']))).'" role="button" title="Edit">
+                <i class="fas fa-edit text-primary"></i>
+            </a>
+        </td>
         <td>';
     foreach ($version->getNbVersionsPluginVersions() as $nbvPv) {
             echo '<span class="badge badge-brown">NB '.$nbvPv->getNbVersion()->getVersion().'</span>&nbsp; ';

--- a/pp3/module/Application/view/application/plugin-version/edit.phtml
+++ b/pp3/module/Application/view/application/plugin-version/edit.phtml
@@ -27,7 +27,7 @@
             echo $this->partial('application/plugin-version/_pluginVersion-form.phtml', 
             array('pluginVersion' => $this->pluginVersion, 'nbVersions' => $this->nbVersions, 'verifiedNbVersionIds' => $this->verifiedNbVersionIds)); 
             ?>
-            <a class="btn btn-secondary" href="../plugin/list" role="button">Return</a>
+            <a class="btn btn-secondary" href="<?= $this->return ?>" role="button">Return</a>
             <button type="submit" class="btn btn-primary">Save Plugin Version</button>
             </form>
             


### PR DESCRIPTION
It is important for Plugin Portal administrators to have a UI how to add missing or fix incorrect mapping between plugin version(s) and NetBeans version(s) and also request/cancel verifications.

https://issues.apache.org/jira/browse/NETBEANS-3492