### PR TITLE
Update of URLs in notification e-mails from Plugin Portal 3.0

### DIFF
--- a/pp3/module/Application/src/Application/Controller/VerificationController.php
+++ b/pp3/module/Application/src/Application/Controller/VerificationController.php
@@ -225,7 +225,7 @@ Verification status: GO
 
 Your plugin should be already available on the Plugin Portal Update Center by now:
 
-http://netbeans-vm.apache.org/pluginportal/data/'.$nbVersion.'/catalog.xml.gz
+https://plugins.netbeans.apache.org/data/'.$nbVersion.'/catalog.xml.gz
 
 Thanks for your contribution!
 NetBeans development team

--- a/pp3/module/Application/src/Application/Controller/VerificationController.php
+++ b/pp3/module/Application/src/Application/Controller/VerificationController.php
@@ -196,7 +196,7 @@ Comments: '.$comment.'
 
 If your plugin was verified successfully, it should be already available on the Plugin Portal Update Center by now:
 
-http://netbeans-vm.apache.org/pluginportal/data/'.$nbVersion.'/catalog.xml.gz
+https://plugins.netbeans.apache.org/data/'.$nbVersion.'/catalog.xml.gz
 
 Thanks for your contribution!
 NetBeans development team

--- a/pp3/module/Application/src/Application/Controller/VerificationController.php
+++ b/pp3/module/Application/src/Application/Controller/VerificationController.php
@@ -194,11 +194,9 @@ NetBeans version: '.$nbVersion.'
 Verification status: NOGO
 Comments: '.$comment.'
 
-If your plugin was verified successfully, it should be already available on the Plugin Portal Update Center by now:
+Do not give up though. Address the comment(s), upload new binary of your plugin and request the verification again!
 
-https://plugins.netbeans.apache.org/data/'.$nbVersion.'/catalog.xml.gz
-
-Thanks for your contribution!
+Good luck!
 NetBeans development team
 
 P.S.: This is an automatic email. DO NOT REPLY to this email.');

--- a/pp3/module/Application/src/Application/Entity/VerificationRequest.php
+++ b/pp3/module/Application/src/Application/Entity/VerificationRequest.php
@@ -28,7 +28,7 @@ NetBeans version: '.$this->getVerification()->getNbVersionPluginVersion()->getNb
 
 Please login to the NetBeans Plugin Portal at your earliest convenience, test the plugin above in Apache NetBeans IDE it was written for and either Approve or Reject publishing the plugin on the target Plugin Portal Update Center. The testing should validate that the plugin can be installed, deactivated, activated and uninstalled smoothly. If it registers its own Update Center, the uninstallation of the plugin removes the Update Center as well. If you decide to reject a plugin, please include appropriate justification in the comments field for the plugin owner.
 
-http://netbeans-vm.apache.org/pluginportal/verification/list
+https://plugins.netbeans.apache.org/verification/list
 
 Thanks for your help!
 NetBeans development team


### PR DESCRIPTION
Now that Plugin Portal 3.0 has got its own domain, the URLs in e-mail notifications should be updated to stop referring to the http://netbeans-vm.apache.org/pluginportal host and rather use own https://plugins.netbeans.apache.org with secure protocol.