### PR TITLE
last_updated_at is explicitly handled in code and should not be auto updated

### DIFF
--- a/pp3/config/pp3.sql
+++ b/pp3/config/pp3.sql
@@ -68,7 +68,7 @@ CREATE TABLE IF NOT EXISTS `plugin` (
   `license` varchar(255) COLLATE utf8_czech_ci DEFAULT NULL,
   `author_id` int(11) NOT NULL REFERENCES user(id),
   `added_at` datetime DEFAULT CURRENT_TIMESTAMP,
-  `last_updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `last_updated_at` datetime DEFAULT CURRENT_TIMESTAMP,
   `approved_at` datetime DEFAULT NULL,
   `url` varchar(255) COLLATE utf8_czech_ci DEFAULT NULL,
   `status` int(11) DEFAULT NULL,


### PR DESCRIPTION
The automatic update of the last_update_at timestamp creates irritating
user experience. The plugin table hold a download counter, so every
download is an update to the plugin row and will trigger the auto update
of the timestamp, which is not the timestamp the user would expect.

https://issues.apache.org/jira/browse/NETBEANS-3823#