### PR TITLE
Prepare for a release of NBPackage

### DIFF
--- a/nbpackage/.gitignore
+++ b/nbpackage/.gitignore
@@ -7,3 +7,6 @@
 target/
 .flattened-pom.xml
 dependency-reduced-pom.xml
+
+# NetBeans related files #
+nbproject/

--- a/nbpackage/NOTICE
+++ b/nbpackage/NOTICE
@@ -9,3 +9,6 @@ Parts of this software are derived from the libgdx Packr project, under Apache L
   Copyright (c) 2020 Daniel Ludwig, code-disaster, codi at code-disaster dot com
   Copyright (c) 2020 Karl Sabo, Nimbly Games, karl@nimblygames.com
   Copyright (c) 2020 petoncle, albert.petoncle47@gmail.com
+
+Launch scripts are derived from templates in the AppAssembler plugin, under MIT license.
+  Copyright 2006-2012 The Codehaus.

--- a/nbpackage/pom.xml
+++ b/nbpackage/pom.xml
@@ -28,7 +28,7 @@ under the License.
   
   <groupId>org.apache.netbeans</groupId>
   <artifactId>nbpackage</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0-beta1-SNAPSHOT</version>
   <packaging>jar</packaging>
   
   <name>Apache NetBeans NBPackage</name>

--- a/nbpackage/pom.xml
+++ b/nbpackage/pom.xml
@@ -73,27 +73,51 @@ under the License.
         <version>2.22.2</version>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>appassembler-maven-plugin</artifactId>
-        <version>2.1.0</version>
-        <configuration>
-          <repositoryLayout>flat</repositoryLayout>
-          <repositoryName>mods</repositoryName>
-          <useWildcardClassPath>true</useWildcardClassPath>
-          <unixScriptTemplate>${project.basedir}/src/bin/unixBinTemplate</unixScriptTemplate>
-          <windowsScriptTemplate>${project.basedir}/src/bin/windowsBinTemplate</windowsScriptTemplate>
-          <programs>
-            <program>
-              <id>nbpackage</id>
-              <mainClass>org.apache.netbeans.nbpackage/org.apache.netbeans.nbpackage.Main</mainClass>
-            </program>
-          </programs>
-        </configuration>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.4.2</version>
         <executions>
           <execution>
+            <id>make-src</id>
+            <phase>package</phase>
             <goals>
-              <goal>assemble</goal>
+              <goal>single</goal>
             </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>${basedir}/src/assembly/src.xml</descriptor>
+              </descriptors>
+              <attach>false</attach>
+              <tarLongFileMode>gnu</tarLongFileMode>
+            </configuration>
+          </execution>
+          <execution>
+            <id>make-bin</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>${basedir}/src/assembly/bin.xml</descriptor>
+              </descriptors>
+              <attach>false</attach>
+              <tarLongFileMode>gnu</tarLongFileMode>
+            </configuration>
+          </execution>
+          <execution>
+            <id>make-bin-dir</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>${basedir}/src/assembly/dir.xml</descriptor>
+              </descriptors>
+              <appendAssemblyId>false</appendAssemblyId>
+              <attach>false</attach>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/nbpackage/pom.xml
+++ b/nbpackage/pom.xml
@@ -19,12 +19,27 @@ under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <groupId>org.apache.netbeans</groupId>
+    <artifactId>netbeans-parent</artifactId>
+    <version>3</version>
+  </parent>
+  
   <groupId>org.apache.netbeans</groupId>
   <artifactId>nbpackage</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   
-  <name>NBPackage</name>
+  <name>Apache NetBeans NBPackage</name>
+  <url>https://netbeans.apache.org</url>
+  <description>Apache NetBeans packaging utility.</description>
+  
+  <scm>
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/netbeans-tools.git</connection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/netbeans-tools.git</developerConnection>
+    <url>https://github.com/apache/netbeans-tools</url>
+  </scm>
   
   <dependencies>
     <dependency>
@@ -73,6 +88,30 @@ under the License.
         <version>2.22.2</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <!-- exclude template files - no creativity; currently no way to filter out license --> 
+            <exclude>**/*.template</exclude>
+            <!-- exclude Apache NetBeans SVG - license header causes display issues on certain OS -->
+            <exclude>**/apache-netbeans.svg</exclude>
+            <!-- exclude NetBeans configuration files, not in source bundle -->
+            <exclude>nbactions.xml</exclude>
+            <exclude>nb-configuration.xml</exclude>
+            <!-- misc excludes -->
+            <exclude>README.md</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>3.4.2</version>
@@ -88,7 +127,6 @@ under the License.
                 <descriptor>${basedir}/src/assembly/src.xml</descriptor>
               </descriptors>
               <attach>false</attach>
-              <tarLongFileMode>gnu</tarLongFileMode>
             </configuration>
           </execution>
           <execution>
@@ -102,7 +140,6 @@ under the License.
                 <descriptor>${basedir}/src/assembly/bin.xml</descriptor>
               </descriptors>
               <attach>false</attach>
-              <tarLongFileMode>gnu</tarLongFileMode>
             </configuration>
           </execution>
           <execution>

--- a/nbpackage/pom.xml
+++ b/nbpackage/pom.xml
@@ -73,11 +73,23 @@ under the License.
   </dependencies>
   
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.4.1</version>
+          <configuration>
+            <release>11</release>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.10.1</version>
         <configuration>
           <release>11</release>
         </configuration>

--- a/nbpackage/src/assembly/_dist.xml
+++ b/nbpackage/src/assembly/_dist.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<component xmlns="http://maven.apache.org/ASSEMBLY-COMPONENT/2.1.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY-COMPONENT/2.1.0 https://maven.apache.org/xsd/assembly-component-2.1.0.xsd">
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>mods</outputDirectory>
+    </dependencySet>
+  </dependencySets>
+  <fileSets>
+    <fileSet>
+      <includes>
+        <include>README*</include>
+        <include>LICENSE*</include>
+        <include>NOTICE*</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+  <files>
+    <file>
+      <source>src/assembly/bin/nbpackage</source>
+      <outputDirectory>bin</outputDirectory>
+      <lineEnding>unix</lineEnding>
+      <fileMode>0755</fileMode>
+    </file>
+    <file>
+      <source>src/assembly/bin/nbpackage.cmd</source>
+      <outputDirectory>bin</outputDirectory>
+      <lineEnding>dos</lineEnding>
+    </file>
+  </files>
+</component>

--- a/nbpackage/src/assembly/bin.xml
+++ b/nbpackage/src/assembly/bin.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.1 https://maven.apache.org/xsd/assembly-2.1.1.xsd">
+  <id>bin</id>
+  <formats>
+    <format>tar.gz</format>
+    <format>zip</format>
+  </formats>
+  <componentDescriptors>
+    <componentDescriptor>src/assembly/_dist.xml</componentDescriptor>
+  </componentDescriptors>
+</assembly>

--- a/nbpackage/src/assembly/bin/nbpackage
+++ b/nbpackage/src/assembly/bin/nbpackage
@@ -1,0 +1,123 @@
+#!/usr/bin/env sh
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Derived from AppAssembler plugin template - see NOTICE.
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+PRGDIR=`dirname "$PRG"`
+BASEDIR=`cd "$PRGDIR/.." >/dev/null; pwd`
+
+# Reset the REPO variable. If you need to influence this use the environment setup file.
+REPO=
+
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -x "$BASEDIR/jdk/" ] ; then
+    JAVACMD="$BASEDIR/jdk/bin/java"
+  fi
+fi
+
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+case "`uname`" in
+  CYGWIN*) cygwin=true ;;
+  Darwin*) darwin=true
+           if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+		   if [ -z "$JAVA_HOME" ]; then
+		      if [ -x "/usr/libexec/java_home" ]; then
+			      JAVA_HOME=`/usr/libexec/java_home`
+			  else
+			      JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+			  fi
+           fi       
+           ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=`java-config --jre-home`
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# If a specific java binary isn't specified search for the standard 'java' binary
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=`which java`
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." 1>&2
+  echo "  We cannot execute $JAVACMD" 1>&2
+  exit 1
+fi
+
+if [ -z "$REPO" ]
+then
+  REPO="$BASEDIR"/mods
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
+  [ -n "$HOME" ] && HOME=`cygpath --path --windows "$HOME"`
+  [ -n "$BASEDIR" ] && BASEDIR=`cygpath --path --windows "$BASEDIR"`
+  [ -n "$REPO" ] && REPO=`cygpath --path --windows "$REPO"`
+fi
+
+exec "$JAVACMD" $JAVA_OPTS  \
+  -p "$REPO" \
+  -Dapp.name="nbpackage" \
+  -Dapp.pid="$$" \
+  -Dapp.repo="$REPO" \
+  -Dapp.home="$BASEDIR" \
+  -Dbasedir="$BASEDIR" \
+  -m org.apache.netbeans.nbpackage/org.apache.netbeans.nbpackage.Main \
+  "$@"

--- a/nbpackage/src/assembly/bin/nbpackage.cmd
+++ b/nbpackage/src/assembly/bin/nbpackage.cmd
@@ -1,0 +1,113 @@
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM 
+@REM   http://www.apache.org/licenses/LICENSE-2.0
+@REM 
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM
+@REM Derived from AppAssembler plugin template - see NOTICE.
+
+@echo off
+
+set ERROR_CODE=0
+
+:init
+@REM Decide how to startup depending on the version of windows
+
+@REM -- Win98ME
+if NOT "%OS%"=="Windows_NT" goto Win9xArg
+
+@REM set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" @setlocal
+
+@REM -- 4NT shell
+if "%eval[2+2]" == "4" goto 4NTArgs
+
+@REM -- Regular WinNT shell
+set CMD_LINE_ARGS=%*
+goto WinNTGetScriptDir
+
+@REM The 4NT Shell from jp software
+:4NTArgs
+set CMD_LINE_ARGS=%$
+goto WinNTGetScriptDir
+
+:Win9xArg
+@REM Slurp the command line arguments.  This loop allows for an unlimited number
+@REM of arguments (up to the command line limit, anyway).
+set CMD_LINE_ARGS=
+:Win9xApp
+if %1a==a goto Win9xGetScriptDir
+set CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
+shift
+goto Win9xApp
+
+:Win9xGetScriptDir
+set SAVEDIR=%CD%
+%0\
+cd %0\..\.. 
+set BASEDIR=%CD%
+cd %SAVEDIR%
+set SAVE_DIR=
+goto repoSetup
+
+:WinNTGetScriptDir
+for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
+echo %~dp0
+echo %~dp0..
+echo %BASEDIR%
+
+:repoSetup
+set REPO=
+
+
+if exist %BASEDIR%\jdk set JAVA_HOME=%BASEDIR%\jdk
+
+if not "%JAVA_HOME%"=="" set JAVACMD=%JAVA_HOME%\bin\java
+
+if "%JAVACMD%"=="" set JAVACMD=java
+
+if "%REPO%"=="" set REPO=%BASEDIR%\mods
+
+@REM Reaching here means variables are defined and arguments have been captured
+:endInit
+
+"%JAVACMD%" %JAVA_OPTS%  -p "%REPO%" -Dapp.name="nbpackage" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" -m "org.apache.netbeans.nbpackage/org.apache.netbeans.nbpackage.Main" %CMD_LINE_ARGS%
+if %ERRORLEVEL% NEQ 0 goto error
+goto end
+
+:error
+if "%OS%"=="Windows_NT" @endlocal
+set ERROR_CODE=%ERRORLEVEL%
+
+:end
+@REM set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" goto endNT
+
+@REM For old DOS remove the set variables from ENV - we assume they were not set
+@REM before we started - at least we don't leave any baggage around
+set CMD_LINE_ARGS=
+goto postExec
+
+:endNT
+@REM If error code is set to 1 then the endlocal was done already in :error.
+if %ERROR_CODE% EQU 0 @endlocal
+
+
+:postExec
+
+if "%FORCE_EXIT_ON_ERROR%" == "on" (
+  if %ERROR_CODE% NEQ 0 exit %ERROR_CODE%
+)
+
+exit /B %ERROR_CODE%

--- a/nbpackage/src/assembly/dir.xml
+++ b/nbpackage/src/assembly/dir.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.1 https://maven.apache.org/xsd/assembly-2.1.1.xsd">
+  <id>dir</id>
+  <formats>
+    <format>dir</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <componentDescriptors>
+    <componentDescriptor>src/assembly/_dist.xml</componentDescriptor>
+  </componentDescriptors>
+</assembly>
+

--- a/nbpackage/src/assembly/src.xml
+++ b/nbpackage/src/assembly/src.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.1 https://maven.apache.org/xsd/assembly-2.1.1.xsd">
+  <id>src</id>
+  <formats>
+    <format>tar.gz</format>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <includes>
+        <include>README*</include>
+        <include>LICENSE*</include>
+        <include>NOTICE*</include>
+        <include>pom.xml</include>
+      </includes>
+      <useDefaultExcludes>true</useDefaultExcludes>
+    </fileSet>
+    <fileSet>
+      <directory>src</directory>
+      <useDefaultExcludes>true</useDefaultExcludes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/nbpackage/src/main/java/module-info.java
+++ b/nbpackage/src/main/java/module-info.java
@@ -18,10 +18,11 @@
  */
 module org.apache.netbeans.nbpackage {
     
+    exports org.apache.netbeans.nbpackage;
+    
     requires info.picocli;
     requires org.apache.commons.compress;
     
     opens org.apache.netbeans.nbpackage to info.picocli;
 
-    
 }

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/AbstractPackagerTask.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/AbstractPackagerTask.java
@@ -34,6 +34,11 @@ public abstract class AbstractPackagerTask implements Packager.Task {
 
     private final ExecutionContext context;
 
+    /**
+     * Create task with provided context.
+     * 
+     * @param context execution context
+     */
     protected AbstractPackagerTask(ExecutionContext context) {
         this.context = Objects.requireNonNull(context);
     }
@@ -57,7 +62,7 @@ public abstract class AbstractPackagerTask implements Packager.Task {
      *
      * @param input file or directory
      * @return path to image
-     * @throws Exception
+     * @throws Exception if unable to create image
      */
     @Override
     public Path createImage(Path input) throws Exception {
@@ -132,7 +137,7 @@ public abstract class AbstractPackagerTask implements Packager.Task {
      *
      * @param image image directory
      * @return resolved application path inside image
-     * @throws Exception
+     * @throws Exception if unable to compute path
      */
     protected Path applicationDirectory(Path image) throws Exception {
         return image;
@@ -147,7 +152,7 @@ public abstract class AbstractPackagerTask implements Packager.Task {
      * @param image image path
      * @param application application path
      * @return resolved runtime path inside image
-     * @throws Exception
+     * @throws Exception if unable to compute path
      */
     protected Path runtimeDirectory(Path image, Path application) throws Exception {
         return application.resolve("jdk");

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/ExecutionContext.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/ExecutionContext.java
@@ -271,8 +271,8 @@ public final class ExecutionContext {
      * Get the value of the provided {@link Option} if set. Tokens in the text
      * will be replaced before the option is parsed.
      * <p>
-     * Will return {@link Optional#EMPTY} if the value has not been set and has
-     * no default. Will throw an exception if a value exists and cannot be
+     * Will return {@link Optional#empty()} if the value has not been set and
+     * has no default. Will throw an exception if a value exists and cannot be
      * parsed by the option.
      *
      * @param <T> option type
@@ -352,8 +352,8 @@ public final class ExecutionContext {
 
     /**
      * Default token lookup. Useful if a task wants to provide its own token
-     * value source in
-     * {@link #replaceTokens(java.lang.String, java.util.function.UnaryOperator)}
+     * value source in eg.
+     * {@link StringUtils#replaceTokens(java.lang.String, java.util.function.Function)}
      * but fallback to the default token replacement.
      *
      * @param token key to replace

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/Main.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/Main.java
@@ -21,6 +21,7 @@ package org.apache.netbeans.nbpackage;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Path;
+import java.text.MessageFormat;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -43,7 +44,7 @@ public class Main {
         System.exit(ret);
     }
 
-    @CommandLine.Command(mixinStandardHelpOptions = true)
+    @CommandLine.Command(mixinStandardHelpOptions = true, versionProvider = VersionProvider.class)
     private static class Launcher implements Callable<Integer> {
 
         @CommandLine.Option(names = {"-t", "--type"},
@@ -71,7 +72,7 @@ public class Main {
         @CommandLine.Option(names = {"--save-config"},
                 descriptionKey = "option.saveconfig.description")
         private Path configOut;
-        
+
         @CommandLine.Option(names = {"--save-templates"},
                 descriptionKey = "option.savetemplates.description")
         private Path templatesOut;
@@ -116,7 +117,7 @@ public class Main {
                         cb.set(opt, value);
                     });
                 }
-                
+
                 if (verbose) {
                     cb.verbose();
                 }
@@ -130,7 +131,7 @@ public class Main {
                 if (templatesOut != null) {
                     NBPackage.copyTemplates(conf, templatesOut);
                 }
-                
+
                 Path dest = output == null ? Path.of("") : output;
 
                 Path created = null;
@@ -167,10 +168,10 @@ public class Main {
             );
             System.out.println(ansiMsg);
         }
-        
+
         private boolean hasAuxTasks() {
             return configOut != null || templatesOut != null;
-        } 
+        }
 
     }
 
@@ -179,6 +180,19 @@ public class Main {
         @Override
         public Iterator<String> iterator() {
             return NBPackage.packagers().map(Packager::name).sorted().iterator();
+        }
+
+    }
+
+    private static class VersionProvider implements CommandLine.IVersionProvider {
+
+        @Override
+        public String[] getVersion() throws Exception {
+            String msg = MessageFormat.format(
+                    NBPackage.MESSAGES.getString("message.version"),
+                    NBPackage.version().orElse("<DEV>")
+            );
+            return new String[]{msg};
         }
 
     }

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/NBPackage.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/NBPackage.java
@@ -19,11 +19,14 @@
 package org.apache.netbeans.nbpackage;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.stream.Stream;
 import org.apache.netbeans.nbpackage.appimage.AppImagePackager;
@@ -310,6 +313,28 @@ public final class NBPackage {
      */
     public static Stream<Template> templates(String packagerName) {
         return findPackager(packagerName).templates();
+    }
+
+    /**
+     * Query NBPackage version (if available).
+     *
+     * @return version or empty optional if no version information
+     */
+    public static Optional<String> version() {
+        String version = null;
+
+        try (InputStream pomProps = NBPackage.class.getResourceAsStream(
+                "/META-INF/maven/org.apache.netbeans/nbpackage/pom.properties")) {
+            if (pomProps != null) {
+                Properties p = new Properties();
+                p.load(pomProps);
+                version = p.getProperty("version");
+            }
+        } catch (Exception ex) {
+            // fall through
+        }
+
+        return Optional.ofNullable(version);
     }
 
     // @TODO properly escape and support multi-line comments / values

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/Packager.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/Packager.java
@@ -101,10 +101,10 @@ public interface Packager {
 
         /**
          * Create a package from the image and additional files created by
-         * {@link #createImage()} and
-         * {@link #createBuildFiles(java.nio.file.Path)}.
+         * {@link #createImage(java.nio.file.Path)}.
          *
-         * @param image image created by {@link #createImage()}
+         * @param image image created by
+         * {@link #createImage(java.nio.file.Path)}
          * @return path to created package
          * @throws Exception on execution failure
          */

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/Messages.properties
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/Messages.properties
@@ -49,3 +49,4 @@ message.validatingpackage=Checking package creation prerequisites.
 message.creatingimage=Building image from {0}.
 message.creatingpackage=Building package from {0}.
 message.outputcreated=Successfully built {0}.
+message.version=Apache NetBeans NBPackage version {0}


### PR DESCRIPTION
Some steps to prepare to do a release of NBPackage.

Move from AppAssembler to Assembly plugin, with binary and source archives.
Update POM to use netbeans-parent and enable RAT checks.
Add missing version query.