### PR TITLE
NBPackage RPM fixes and options tidy up towards first release

### DIFF
--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/Main.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/Main.java
@@ -111,7 +111,7 @@ public class Main {
                 if (options != null && !options.isEmpty()) {
                     options.forEach((key, value) -> {
                         var opt = NBPackage.options()
-                                .filter(o -> o.key().equals(key))
+                                .filter(o -> o.key().equals(key) || o.key().equals("package." + key))
                                 .findFirst()
                                 .orElseThrow(() -> new IllegalArgumentException(key));
                         cb.set(opt, value);

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/NBPackage.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/NBPackage.java
@@ -20,6 +20,7 @@ package org.apache.netbeans.nbpackage;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -48,7 +49,7 @@ public final class NBPackage {
      * Option definition for package name.
      */
     public static final Option<String> PACKAGE_NAME = Option.ofString(
-            "package.name", "", MESSAGES.getString("option.name.help"));
+            "package.name", MESSAGES.getString("option.name.help"));
 
     /**
      * Option definition for package version.
@@ -60,14 +61,45 @@ public final class NBPackage {
      * Option definition for package type.
      */
     public static final Option<String> PACKAGE_TYPE = Option.ofString(
-            "package.type", "", MESSAGES.getString("option.type.help"));
+            "package.type", MESSAGES.getString("option.type.help"));
 
     /**
      * Option definition for path to the optional Java runtime to include in the
      * package.
      */
     public static final Option<Path> PACKAGE_RUNTIME = Option.ofPath(
-            "package.runtime", "", MESSAGES.getString("option.runtime.help"));
+            "package.runtime", MESSAGES.getString("option.runtime.help"));
+
+    /**
+     * Option definition for package publisher.
+     */
+    public static final Option<String> PACKAGE_PUBLISHER = Option.ofString(
+            "package.publisher",
+            MESSAGES.getString("option.publisher.default"),
+            MESSAGES.getString("option.publisher.help"));
+
+    /**
+     * Option definition for package URL.
+     */
+    public static final Option<URI> PACKAGE_URL = Option.of("package.url",
+            URI.class,
+            "",
+            s -> {
+                var uri = new URI(s);
+                if (uri.isAbsolute()) {
+                    return uri;
+                }
+                throw new IllegalArgumentException();
+            },
+            MESSAGES.getString("option.url.help"));
+
+    /**
+     * Option definition for summary description.
+     */
+    public static final Option<String> PACKAGE_DESCRIPTION = Option.ofString(
+            "package.description",
+            MESSAGES.getString("option.description.default"),
+            MESSAGES.getString("option.description.help"));
 
 // @TODO generate list from service loader if modularizing
     private static final List<Packager> PACKAGERS = List.of(
@@ -80,7 +112,8 @@ public final class NBPackage {
     );
 
     private static final List<Option<?>> GLOBAL_OPTIONS
-            = List.of(PACKAGE_NAME, PACKAGE_VERSION, PACKAGE_TYPE, PACKAGE_RUNTIME);
+            = List.of(PACKAGE_NAME, PACKAGE_VERSION, PACKAGE_TYPE, PACKAGE_RUNTIME,
+                    PACKAGE_DESCRIPTION, PACKAGE_PUBLISHER, PACKAGE_URL);
 
     private NBPackage() {
         // no op

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/appimage/AppImagePackager.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/appimage/AppImagePackager.java
@@ -40,14 +40,14 @@ public class AppImagePackager implements Packager {
      */
     static final Option<Path> APPIMAGE_TOOL
             = Option.ofPath("package.appimage.tool", "",
-                    MESSAGES.getString("option.appimagetool.description"));
+                    MESSAGES.getString("option.appimagetool.help"));
 
     /**
      * Path to png icon (48x48) as required by AppDir / XDG specification.
      */
     static final Option<Path> APPIMAGE_ICON
             = Option.ofPath("package.appimage.icon", "",
-                    MESSAGES.getString("option.appimageicon.description"));
+                    MESSAGES.getString("option.appimageicon.help"));
 
     /**
      * Category (or categories) to set in .desktop file.
@@ -55,7 +55,7 @@ public class AppImagePackager implements Packager {
     static final Option<String> APPIMAGE_CATEGORY
             = Option.ofString("package.appimage.category",
                     "Development;Java;IDE;",
-                    MESSAGES.getString("option.appimagecategory.description"));
+                    MESSAGES.getString("option.appimagecategory.help"));
 
     /**
      * Architecture of AppImage to create. Defaults to parsing from appimagetool
@@ -64,14 +64,14 @@ public class AppImagePackager implements Packager {
     static final Option<String> APPIMAGE_ARCH
             = Option.ofString("package.appimage.arch",
                     "",
-                    MESSAGES.getString("option.appimagearch.description"));
+                    MESSAGES.getString("option.appimagearch.help"));
     
     /**
      * Optional path to custom .desktop template.
      */
     static final Option<Path> DESKTOP_TEMPLATE_PATH
             = Option.ofPath("package.appimage.desktop-template",
-                    MESSAGES.getString("option.desktop_template.description"));
+                    MESSAGES.getString("option.desktop_template.help"));
 
     /**
      * Desktop file template.
@@ -85,7 +85,7 @@ public class AppImagePackager implements Packager {
      */
     static final Option<Path> LAUNCHER_TEMPLATE_PATH
             = Option.ofPath("package.appimage.launcher-template",
-                    MESSAGES.getString("option.launcher_template.description"));
+                    MESSAGES.getString("option.launcher_template.help"));
 
     /**
      * AppRun launcher script template.

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/appimage/AppImagePackager.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/appimage/AppImagePackager.java
@@ -39,23 +39,23 @@ public class AppImagePackager implements Packager {
      * Path to appimagetool executable.
      */
     static final Option<Path> APPIMAGE_TOOL
-            = Option.ofPath("package.appimage.tool", "",
-                    MESSAGES.getString("option.appimagetool.help"));
+            = Option.ofPath("package.appimage.tool",
+                    MESSAGES.getString("option.tool.help"));
 
     /**
      * Path to png icon (48x48) as required by AppDir / XDG specification.
      */
     static final Option<Path> APPIMAGE_ICON
-            = Option.ofPath("package.appimage.icon", "",
-                    MESSAGES.getString("option.appimageicon.help"));
+            = Option.ofPath("package.appimage.icon",
+                    MESSAGES.getString("option.icon.help"));
 
     /**
      * Category (or categories) to set in .desktop file.
      */
     static final Option<String> APPIMAGE_CATEGORY
             = Option.ofString("package.appimage.category",
-                    "Development;Java;IDE;",
-                    MESSAGES.getString("option.appimagecategory.help"));
+                    MESSAGES.getString("option.category.default"),
+                    MESSAGES.getString("option.category.help"));
 
     /**
      * Architecture of AppImage to create. Defaults to parsing from appimagetool
@@ -63,8 +63,7 @@ public class AppImagePackager implements Packager {
      */
     static final Option<String> APPIMAGE_ARCH
             = Option.ofString("package.appimage.arch",
-                    "",
-                    MESSAGES.getString("option.appimagearch.help"));
+                    MESSAGES.getString("option.arch.help"));
     
     /**
      * Optional path to custom .desktop template.

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/deb/DebPackager.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/deb/DebPackager.java
@@ -41,7 +41,7 @@ public class DebPackager implements Packager {
      */
     static final Option<Path> ICON_PATH
             = Option.ofPath("package.deb.icon", "",
-                    MESSAGES.getString("option.icon.description"));
+                    MESSAGES.getString("option.icon.help"));
 
     /**
      * Path to svg icon. Will only be used if DEB_ICON is also set. Defaults to
@@ -49,7 +49,7 @@ public class DebPackager implements Packager {
      */
     static final Option<Path> SVG_ICON_PATH
             = Option.ofPath("package.deb.svg-icon", "",
-                    MESSAGES.getString("option.svg.description"));
+                    MESSAGES.getString("option.svg.help"));
 
     /**
      * Name for the .desktop file (without suffix). Defaults to sanitized
@@ -57,7 +57,7 @@ public class DebPackager implements Packager {
      */
     static final Option<String> DESKTOP_FILENAME
             = Option.ofString("package.deb.desktop-filename", "",
-                    MESSAGES.getString("option.desktopfilename.description"));
+                    MESSAGES.getString("option.desktopfilename.help"));
 
     /**
      * StartupWMClass to set in .desktop file.
@@ -65,7 +65,7 @@ public class DebPackager implements Packager {
     static final Option<String> DESKTOP_WMCLASS
             = Option.ofString("package.deb.wmclass",
                     "${package.name}",
-                    MESSAGES.getString("option.wmclass.description"));
+                    MESSAGES.getString("option.wmclass.help"));
 
     /**
      * Category (or categories) to set in .desktop file.
@@ -73,14 +73,14 @@ public class DebPackager implements Packager {
     static final Option<String> DESKTOP_CATEGORY
             = Option.ofString("package.deb.category",
                     "Development;Java;IDE;",
-                    MESSAGES.getString("option.category.description"));
+                    MESSAGES.getString("option.category.help"));
 
     /**
      * Maintainer name and email for Debian Control file.
      */
     static final Option<String> DEB_MAINTAINER
             = Option.ofString("package.deb.maintainer", "",
-                    MESSAGES.getString("option.maintainer.description"));
+                    MESSAGES.getString("option.maintainer.help"));
 
     /**
      * Package description for Debian Control file.
@@ -88,14 +88,14 @@ public class DebPackager implements Packager {
     static final Option<String> DEB_DESCRIPTION
             = Option.ofString("package.deb.description",
                     "Package of ${package.name} ${package.version}.",
-                    MESSAGES.getString("option.description.description"));
+                    MESSAGES.getString("option.description.help"));
 
     /**
      * Optional path to custom DEB control template.
      */
     static final Option<Path> CONTROL_TEMPLATE_PATH
             = Option.ofPath("package.deb.control-template",
-                    MESSAGES.getString("option.control_template.description"));
+                    MESSAGES.getString("option.control_template.help"));
 
     /**
      * DEB control template.
@@ -109,7 +109,7 @@ public class DebPackager implements Packager {
      */
     static final Option<Path> DESKTOP_TEMPLATE_PATH
             = Option.ofPath("package.deb.desktop-template",
-                    MESSAGES.getString("option.desktop_template.description"));
+                    MESSAGES.getString("option.desktop_template.help"));
 
     /**
      * Desktop file template.
@@ -123,7 +123,7 @@ public class DebPackager implements Packager {
      */
     static final Option<Path> LAUNCHER_TEMPLATE_PATH
             = Option.ofPath("package.deb.launcher-template",
-                    MESSAGES.getString("option.launcher_template.description"));
+                    MESSAGES.getString("option.launcher_template.help"));
 
     /**
      * Launcher script template.

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/deb/DebPackager.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/deb/DebPackager.java
@@ -40,7 +40,7 @@ public class DebPackager implements Packager {
      * Defaults to Apache NetBeans icon.
      */
     static final Option<Path> ICON_PATH
-            = Option.ofPath("package.deb.icon", "",
+            = Option.ofPath("package.deb.icon",
                     MESSAGES.getString("option.icon.help"));
 
     /**
@@ -48,7 +48,7 @@ public class DebPackager implements Packager {
      * Apache NetBeans icon.
      */
     static final Option<Path> SVG_ICON_PATH
-            = Option.ofPath("package.deb.svg-icon", "",
+            = Option.ofPath("package.deb.svg-icon",
                     MESSAGES.getString("option.svg.help"));
 
     /**
@@ -56,7 +56,7 @@ public class DebPackager implements Packager {
      * version of package name.
      */
     static final Option<String> DESKTOP_FILENAME
-            = Option.ofString("package.deb.desktop-filename", "",
+            = Option.ofString("package.deb.desktop-filename",
                     MESSAGES.getString("option.desktopfilename.help"));
 
     /**
@@ -64,7 +64,7 @@ public class DebPackager implements Packager {
      */
     static final Option<String> DESKTOP_WMCLASS
             = Option.ofString("package.deb.wmclass",
-                    "${package.name}",
+                    MESSAGES.getString("option.wmclass.default"),
                     MESSAGES.getString("option.wmclass.help"));
 
     /**
@@ -72,7 +72,7 @@ public class DebPackager implements Packager {
      */
     static final Option<String> DESKTOP_CATEGORY
             = Option.ofString("package.deb.category",
-                    "Development;Java;IDE;",
+                    MESSAGES.getString("option.category.default"),
                     MESSAGES.getString("option.category.help"));
 
     /**
@@ -81,14 +81,6 @@ public class DebPackager implements Packager {
     static final Option<String> DEB_MAINTAINER
             = Option.ofString("package.deb.maintainer", "",
                     MESSAGES.getString("option.maintainer.help"));
-
-    /**
-     * Package description for Debian Control file.
-     */
-    static final Option<String> DEB_DESCRIPTION
-            = Option.ofString("package.deb.description",
-                    "Package of ${package.name} ${package.version}.",
-                    MESSAGES.getString("option.description.help"));
 
     /**
      * Optional path to custom DEB control template.
@@ -134,8 +126,8 @@ public class DebPackager implements Packager {
 
     private static final List<Option<?>> DEB_OPTIONS
             = List.of(ICON_PATH, SVG_ICON_PATH, DESKTOP_FILENAME, DESKTOP_WMCLASS,
-                    DESKTOP_CATEGORY, DEB_MAINTAINER, DEB_DESCRIPTION,
-                    CONTROL_TEMPLATE_PATH, DESKTOP_TEMPLATE_PATH, LAUNCHER_TEMPLATE_PATH);
+                    DESKTOP_CATEGORY, DEB_MAINTAINER, CONTROL_TEMPLATE_PATH,
+                    DESKTOP_TEMPLATE_PATH, LAUNCHER_TEMPLATE_PATH);
 
     private static final List<Template> DEB_TEMPLATES
             = List.of(CONTROL_TEMPLATE, DESKTOP_TEMPLATE, LAUNCHER_TEMPLATE);

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/deb/DebTask.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/deb/DebTask.java
@@ -255,7 +255,7 @@ class DebTask extends AbstractPackagerTask {
         if (maintainer.isBlank()) {
             context().warningHandler().accept(DebPackager.MESSAGES.getString("message.nomaintainer"));
         }
-        String description = context().getValue(DebPackager.DEB_DESCRIPTION).orElse("");
+        String description = context().getValue(NBPackage.PACKAGE_DESCRIPTION).orElse("");
         String recommends = context().getValue(NBPackage.PACKAGE_RUNTIME).isPresent()
                 ? ""
                 : "java11-sdk";

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupPackager.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupPackager.java
@@ -41,21 +41,21 @@ public class InnoSetupPackager implements Packager {
      */
     static final Option<Path> TOOL_PATH
             = Option.ofPath("package.innosetup.tool", "",
-                    MESSAGES.getString("option.innosetuptool.description"));
+                    MESSAGES.getString("option.innosetuptool.help"));
 
     /**
      * InnoSetup App ID.
      */
     static final Option<String> APPID
             = Option.ofString("package.innosetup.appid", "",
-                    MESSAGES.getString("option.innosetupappid.description"));
+                    MESSAGES.getString("option.innosetupappid.help"));
 
     /**
      * Path to icon file (*.ico).
      */
     static final Option<Path> ICON_PATH
             = Option.ofPath("package.innosetup.icon", "",
-                    MESSAGES.getString("option.innosetupicon.description"));
+                    MESSAGES.getString("option.innosetupicon.help"));
 
     /**
      * Path to optional license file (*.txt or *.rtf) to display during
@@ -63,14 +63,14 @@ public class InnoSetupPackager implements Packager {
      */
     static final Option<Path> LICENSE_PATH
             = Option.ofPath("package.innosetup.license", "",
-                    MESSAGES.getString("option.innosetuplicense.description"));
+                    MESSAGES.getString("option.innosetuplicense.help"));
 
     /**
      * Path to alternative InnoSetup template.
      */
     static final Option<Path> ISS_TEMPLATE_PATH
             = Option.ofPath("package.innosetup.template", "",
-                    MESSAGES.getString("option.innosetuptemplate.description"));
+                    MESSAGES.getString("option.innosetuptemplate.help"));
     
     /**
      * ISS file template.

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupPackager.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupPackager.java
@@ -41,21 +41,21 @@ public class InnoSetupPackager implements Packager {
      */
     static final Option<Path> TOOL_PATH
             = Option.ofPath("package.innosetup.tool", "",
-                    MESSAGES.getString("option.innosetuptool.help"));
+                    MESSAGES.getString("option.tool.help"));
 
     /**
      * InnoSetup App ID.
      */
     static final Option<String> APPID
             = Option.ofString("package.innosetup.appid", "",
-                    MESSAGES.getString("option.innosetupappid.help"));
+                    MESSAGES.getString("option.appid.help"));
 
     /**
      * Path to icon file (*.ico).
      */
     static final Option<Path> ICON_PATH
             = Option.ofPath("package.innosetup.icon", "",
-                    MESSAGES.getString("option.innosetupicon.help"));
+                    MESSAGES.getString("option.icon.help"));
 
     /**
      * Path to optional license file (*.txt or *.rtf) to display during
@@ -63,14 +63,14 @@ public class InnoSetupPackager implements Packager {
      */
     static final Option<Path> LICENSE_PATH
             = Option.ofPath("package.innosetup.license", "",
-                    MESSAGES.getString("option.innosetuplicense.help"));
+                    MESSAGES.getString("option.license.help"));
 
     /**
      * Path to alternative InnoSetup template.
      */
     static final Option<Path> ISS_TEMPLATE_PATH
             = Option.ofPath("package.innosetup.template", "",
-                    MESSAGES.getString("option.innosetuptemplate.help"));
+                    MESSAGES.getString("option.template.help"));
     
     /**
      * ISS file template.

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/macos/MacOS.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/macos/MacOS.java
@@ -39,21 +39,21 @@ class MacOS {
      */
     static final Option<String> BUNDLE_ID
             = Option.ofString("package.macos.bundleid",
-                    MESSAGES.getString("option.bundle_id.description"));
+                    MESSAGES.getString("option.bundle_id.help"));
 
     /**
      * Path to icon (*.icns) file.
      */
     static final Option<Path> ICON_PATH
             = Option.ofPath("package.macos.icon",
-                    MESSAGES.getString("option.icon.description"));
+                    MESSAGES.getString("option.icon.help"));
 
     /**
      * Optional Info.plist template path.
      */
     static final Option<Path> INFO_TEMPLATE_PATH
             = Option.ofPath("package.macos.info-template",
-                    MESSAGES.getString("option.info_template.description"));
+                    MESSAGES.getString("option.info_template.help"));
 
     /**
      * Info.plist template.
@@ -67,7 +67,7 @@ class MacOS {
      */
     static final Option<Path> LAUNCHER_TEMPLATE_PATH
             = Option.ofPath("package.macos.launcher-template",
-                    MESSAGES.getString("option.launcher_template.description"));
+                    MESSAGES.getString("option.launcher_template.help"));
 
     /**
      * Launcher (main.swift) template.
@@ -94,7 +94,7 @@ class MacOS {
      */
     static final Option<Path> ENTITLEMENTS_TEMPLATE_PATH
             = Option.ofPath("package.macos.entitlements-template",
-                    MESSAGES.getString("option.entitlements_template.description"));
+                    MESSAGES.getString("option.entitlements_template.help"));
 
     /**
      * Codesign entitlements template.
@@ -108,7 +108,7 @@ class MacOS {
      */
     static final Option<String> SIGNING_FILES
             = Option.ofString("package.macos.codesign-files", DEFAULT_BIN_GLOB,
-                    MESSAGES.getString("option.codesign_files.description"));
+                    MESSAGES.getString("option.codesign_files.help"));
 
     /**
      * Search pattern for JARs containing native binaries that need to be code
@@ -116,21 +116,21 @@ class MacOS {
      */
     static final Option<String> SIGNING_JARS
             = Option.ofString("package.macos.codesign-jars", DEFAULT_JAR_BIN_GLOB,
-                    MESSAGES.getString("option.codesign_jars.description"));
+                    MESSAGES.getString("option.codesign_jars.help"));
 
     /**
      * Codesign ID for signing binaries and app bundle.
      */
     static final Option<String> CODESIGN_ID
             = Option.ofString("package.macos.codesign-id",
-                    MESSAGES.getString("option.codesign_id.description"));
+                    MESSAGES.getString("option.codesign_id.help"));
 
     /**
      * Pkgbuild ID for signing installer.
      */
     static final Option<String> PKGBUILD_ID
             = Option.ofString("package.macos.pkgbuild-id",
-                    MESSAGES.getString("option.pkgbuild_id.description"));
+                    MESSAGES.getString("option.pkgbuild_id.help"));
 
     private MacOS() {
     }

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmPackager.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmPackager.java
@@ -41,7 +41,7 @@ public class RpmPackager implements Packager {
      */
     static final Option<Path> ICON_PATH
             = Option.ofPath("package.rpm.icon", "",
-                    MESSAGES.getString("option.icon.description"));
+                    MESSAGES.getString("option.icon.help"));
 
     /**
      * Path to svg icon. Will only be used if RPM_ICON is also set. Defaults to
@@ -49,7 +49,7 @@ public class RpmPackager implements Packager {
      */
     static final Option<Path> SVG_ICON_PATH
             = Option.ofPath("package.rpm.svg-icon", "",
-                    MESSAGES.getString("option.svg.description"));
+                    MESSAGES.getString("option.svg.help"));
 
     /**
      * Name for the .desktop file (without suffix). Defaults to sanitized
@@ -57,7 +57,7 @@ public class RpmPackager implements Packager {
      */
     static final Option<String> DESKTOP_FILENAME
             = Option.ofString("package.rpm.desktop-filename", "",
-                    MESSAGES.getString("option.desktopfilename.description"));
+                    MESSAGES.getString("option.desktopfilename.help"));
 
     /**
      * StartupWMClass to set in .desktop file.
@@ -65,7 +65,7 @@ public class RpmPackager implements Packager {
     static final Option<String> DESKTOP_WMCLASS
             = Option.ofString("package.rpm.wmclass",
                     "${package.name}",
-                    MESSAGES.getString("option.wmclass.description"));
+                    MESSAGES.getString("option.wmclass.help"));
 
     /**
      * Category (or categories) to set in .desktop file.
@@ -73,42 +73,42 @@ public class RpmPackager implements Packager {
     static final Option<String> DESKTOP_CATEGORY
             = Option.ofString("package.rpm.category",
                     "Development;Java;IDE;",
-                    MESSAGES.getString("option.category.description"));
+                    MESSAGES.getString("option.category.help"));
 
     /**
      * Maintainer name and email for the RPM spec.
      */
     static final Option<String> RPM_MAINTAINER
             = Option.ofString("package.rpm.maintainer", "",
-                    MESSAGES.getString("option.maintainer.description"));
+                    MESSAGES.getString("option.maintainer.help"));
     
     /**
      * Vendor of RPM.
      */
     static final Option<String> RPM_VENDOR
             = Option.ofString("package.rpm.vendor", "",
-                    MESSAGES.getString("option.vendor.description"));
+                    MESSAGES.getString("option.vendor.help"));
     
     /**
      * Software license.
      */
     static final Option<String> RPM_LICENSE
             = Option.ofString("package.rpm.license", "Unknown",
-                    MESSAGES.getString("option.license.description"));
+                    MESSAGES.getString("option.license.help"));
     
     /**
      * RPM group.
      */
     static final Option<String> RPM_GROUP
             = Option.ofString("package.rpm.group", "Unknown",
-                    MESSAGES.getString("option.group.description"));
+                    MESSAGES.getString("option.group.help"));
     
     /**
      * URL of the software's website.
      */
     static final Option<String> RPM_URL
             = Option.ofString("package.rpm.url", "Unknown",
-                    MESSAGES.getString("option.url.description"));
+                    MESSAGES.getString("option.url.help"));
 
     /**
      * Package summary for the RPM spec.
@@ -116,7 +116,7 @@ public class RpmPackager implements Packager {
     static final Option<String> RPM_SUMMARY
             = Option.ofString("package.rpm.summary",
                     "Package of ${package.name} ${package.version}.",
-                    MESSAGES.getString("option.summary.description"));
+                    MESSAGES.getString("option.summary.help"));
     
     /**
      * Package description for the RPM spec.
@@ -124,14 +124,14 @@ public class RpmPackager implements Packager {
     static final Option<String> RPM_DESCRIPTION
             = Option.ofString("package.rpm.description",
                     "Package of ${package.name} ${package.version}.",
-                    MESSAGES.getString("option.description.description"));
+                    MESSAGES.getString("option.description.help"));
 
     /**
      * Optional path to custom RPM spec template.
      */
     static final Option<Path> SPEC_TEMPLATE_PATH
             = Option.ofPath("package.rpm.spec-template",
-                    MESSAGES.getString("option.control_template.description"));
+                    MESSAGES.getString("option.control_template.help"));
 
     /**
      * RPM spec template.
@@ -145,7 +145,7 @@ public class RpmPackager implements Packager {
      */
     static final Option<Path> DESKTOP_TEMPLATE_PATH
             = Option.ofPath("package.rpm.desktop-template",
-                    MESSAGES.getString("option.desktop_template.description"));
+                    MESSAGES.getString("option.desktop_template.help"));
 
     /**
      * Desktop file template.
@@ -159,7 +159,7 @@ public class RpmPackager implements Packager {
      */
     static final Option<Path> LAUNCHER_TEMPLATE_PATH
             = Option.ofPath("package.rpm.launcher-template",
-                    MESSAGES.getString("option.launcher_template.description"));
+                    MESSAGES.getString("option.launcher_template.help"));
 
     /**
      * Launcher script template.

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmPackager.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmPackager.java
@@ -40,7 +40,7 @@ public class RpmPackager implements Packager {
      * Defaults to Apache NetBeans icon.
      */
     static final Option<Path> ICON_PATH
-            = Option.ofPath("package.rpm.icon", "",
+            = Option.ofPath("package.rpm.icon",
                     MESSAGES.getString("option.icon.help"));
 
     /**
@@ -48,7 +48,7 @@ public class RpmPackager implements Packager {
      * Apache NetBeans icon.
      */
     static final Option<Path> SVG_ICON_PATH
-            = Option.ofPath("package.rpm.svg-icon", "",
+            = Option.ofPath("package.rpm.svg-icon",
                     MESSAGES.getString("option.svg.help"));
 
     /**
@@ -56,7 +56,7 @@ public class RpmPackager implements Packager {
      * version of package name.
      */
     static final Option<String> DESKTOP_FILENAME
-            = Option.ofString("package.rpm.desktop-filename", "",
+            = Option.ofString("package.rpm.desktop-filename",
                     MESSAGES.getString("option.desktopfilename.help"));
 
     /**
@@ -64,7 +64,7 @@ public class RpmPackager implements Packager {
      */
     static final Option<String> DESKTOP_WMCLASS
             = Option.ofString("package.rpm.wmclass",
-                    "${package.name}",
+                    MESSAGES.getString("option.wmclass.default"),
                     MESSAGES.getString("option.wmclass.help"));
 
     /**
@@ -72,60 +72,32 @@ public class RpmPackager implements Packager {
      */
     static final Option<String> DESKTOP_CATEGORY
             = Option.ofString("package.rpm.category",
-                    "Development;Java;IDE;",
+                    MESSAGES.getString("option.category.default"),
                     MESSAGES.getString("option.category.help"));
 
     /**
      * Maintainer name and email for the RPM spec.
      */
     static final Option<String> RPM_MAINTAINER
-            = Option.ofString("package.rpm.maintainer", "",
+            = Option.ofString("package.rpm.maintainer",
                     MESSAGES.getString("option.maintainer.help"));
-    
-    /**
-     * Vendor of RPM.
-     */
-    static final Option<String> RPM_VENDOR
-            = Option.ofString("package.rpm.vendor", "",
-                    MESSAGES.getString("option.vendor.help"));
     
     /**
      * Software license.
      */
     static final Option<String> RPM_LICENSE
-            = Option.ofString("package.rpm.license", "Unknown",
+            = Option.ofString("package.rpm.license",
+                    MESSAGES.getString("option.license.default"),
                     MESSAGES.getString("option.license.help"));
     
     /**
      * RPM group.
      */
     static final Option<String> RPM_GROUP
-            = Option.ofString("package.rpm.group", "Unknown",
+            = Option.ofString("package.rpm.group",
+                    MESSAGES.getString("option.group.default"),
                     MESSAGES.getString("option.group.help"));
     
-    /**
-     * URL of the software's website.
-     */
-    static final Option<String> RPM_URL
-            = Option.ofString("package.rpm.url", "Unknown",
-                    MESSAGES.getString("option.url.help"));
-
-    /**
-     * Package summary for the RPM spec.
-     */
-    static final Option<String> RPM_SUMMARY
-            = Option.ofString("package.rpm.summary",
-                    "Package of ${package.name} ${package.version}.",
-                    MESSAGES.getString("option.summary.help"));
-    
-    /**
-     * Package description for the RPM spec.
-     */
-    static final Option<String> RPM_DESCRIPTION
-            = Option.ofString("package.rpm.description",
-                    "Package of ${package.name} ${package.version}.",
-                    MESSAGES.getString("option.description.help"));
-
     /**
      * Optional path to custom RPM spec template.
      */
@@ -170,8 +142,7 @@ public class RpmPackager implements Packager {
 
     private static final List<Option<?>> RPM_OPTIONS
             = List.of(ICON_PATH, SVG_ICON_PATH, DESKTOP_FILENAME, DESKTOP_WMCLASS,
-                    DESKTOP_CATEGORY, RPM_MAINTAINER, RPM_VENDOR, 
-                    RPM_LICENSE, RPM_GROUP, RPM_URL, RPM_DESCRIPTION,
+                    DESKTOP_CATEGORY, RPM_MAINTAINER, RPM_LICENSE, RPM_GROUP,
                     SPEC_TEMPLATE_PATH, DESKTOP_TEMPLATE_PATH, LAUNCHER_TEMPLATE_PATH);
 
     private static final List<Template> RPM_TEMPLATES

--- a/nbpackage/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmTask.java
+++ b/nbpackage/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmTask.java
@@ -173,7 +173,7 @@ class RpmTask extends AbstractPackagerTask {
         if (packageArch == null) {
             if (context().getValue(NBPackage.PACKAGE_RUNTIME).isPresent()) {
                 packageArch = context()
-                        .execAndGetOutput(RPM, "--eval '%{_arch}'")
+                        .execAndGetOutput(RPM, "--eval", "%{_arch}")
                         .strip();
             } else {
                 packageArch = "noarch";

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/Messages.properties
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/Messages.properties
@@ -27,7 +27,7 @@ option.saveconfig.description=Path to save configuration for editing. Must not e
 option.savetemplates.description=Path to save templates for editing. Must not exist or be an existing directory.
 option.imageonly.description=Output package image only (advanced).
 option.verbose.description=Output extra diagnostic information during execution.
-option.property.description=Override the value of configuration options - eg. -Ppackage.version=2.2.
+option.property.description=Override the value of configuration options (package. prefix optional) - eg. -Ppackage.version=2.2 or -Pversion=2.2.
 
 # Option file help comments
 option.name.help=Application name (required).

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/Messages.properties
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/Messages.properties
@@ -34,6 +34,13 @@ option.name.help=Application name (required).
 option.version.help=Application version (defaults 1.0).
 option.type.help=Packaging type.
 option.runtime.help=Path to Java runtime to include in the package (default none).
+option.description.help=A single-line description of the package. Not all packagers will display this.
+option.publisher.help=Application publisher. Not all packagers will display this.
+option.url.help=Link to application / publisher website. Not all packagers will display this.
+
+# Option defaults
+option.description.default=Package of ${package.name} ${package.version}.
+option.publisher.default=${package.name}
 
 # Messages
 message.notasks=No tasks specified. Use --input, --input-image or --save-config.

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/Messages.properties
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/Messages.properties
@@ -36,7 +36,6 @@ option.type.help=Packaging type.
 option.runtime.help=Path to Java runtime to include in the package (default none).
 
 # Messages
-
 message.notasks=No tasks specified. Use --input, --input-image or --save-config.
 message.inputandimage=Cannot use --input and --input-image together.
 message.notype=No package type specified.

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/appimage/Messages.properties
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/appimage/Messages.properties
@@ -15,11 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-option.appimagetool.description=Path to appimagetool (required) - can be downloaded from https://github.com/AppImage/AppImageKit/releases/
-option.appimageicon.description=Path to 48x48 png icon as required by xdg specification. Defaults to Apache NetBeans logo.
-option.appimagecategory.description=Application category (or categories) to use in the AppImage .desktop file.
-option.appimagearch.description=Architecture to build appimage for. By default will extract from appimagetool name.
-option.desktop_template.description=Optional path to custom .desktop file template.
-option.launcher_template.description=Optional path to custom AppRun launcher script template.
+# Option file help comments
+option.appimagetool.help=Path to appimagetool (required) - can be downloaded from https://github.com/AppImage/AppImageKit/releases/
+option.appimageicon.help=Path to 48x48 png icon as required by xdg specification. Defaults to Apache NetBeans logo.
+option.appimagecategory.help=Application category (or categories) to use in the AppImage .desktop file.
+option.appimagearch.help=Architecture to build appimage for. By default will extract from appimagetool name.
+option.desktop_template.help=Optional path to custom .desktop file template.
+option.launcher_template.help=Optional path to custom AppRun launcher script template.
 
+# Messages
 message.noappimagetool=The package.appimage.tool option must be set.

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/appimage/Messages.properties
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/appimage/Messages.properties
@@ -16,12 +16,15 @@
 # under the License.
 
 # Option file help comments
-option.appimagetool.help=Path to appimagetool (required) - can be downloaded from https://github.com/AppImage/AppImageKit/releases/
-option.appimageicon.help=Path to 48x48 png icon as required by xdg specification. Defaults to Apache NetBeans logo.
-option.appimagecategory.help=Application category (or categories) to use in the AppImage .desktop file.
-option.appimagearch.help=Architecture to build appimage for. By default will extract from appimagetool name.
+option.tool.help=Path to appimagetool (required) - can be downloaded from https://github.com/AppImage/AppImageKit/releases/
+option.icon.help=Path to 48x48 png icon as required by xdg specification. Defaults to Apache NetBeans logo.
+option.category.help=Application category (or categories) to use in the AppImage .desktop file.
+option.arch.help=Architecture to build appimage for. By default will extract from appimagetool name.
 option.desktop_template.help=Optional path to custom .desktop file template.
 option.launcher_template.help=Optional path to custom AppRun launcher script template.
+
+# Option defaults
+option.category.default=Development;Java;IDE;
 
 # Messages
 message.noappimagetool=The package.appimage.tool option must be set.

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/deb/Messages.properties
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/deb/Messages.properties
@@ -17,7 +17,6 @@
 
 # Option file help comments
 option.maintainer.help=Maintainer information as name and email. Mandated in Debian Control file.
-option.description.help=Description of package for Debian Control file. Defaults to information from package name and version.
 option.icon.help=Path to 48x48 png icon as required by xdg specification. Defaults to Apache NetBeans logo.
 option.svg.help=Path to SVG icon. Will only be used if package.deb.icon also set. Defaults to Apache NetBeans logo.
 option.wmclass.help=StartupWMClass to set in .desktop file. Should match the WMClass of the main application window.
@@ -26,6 +25,10 @@ option.desktopfilename.help=Optional name for .desktop file (without suffix). De
 option.control_template.help=Optional path to custom Debian Control file template.
 option.desktop_template.help=Optional path to custom .desktop file template.
 option.launcher_template.help=Optional path to custom launcher script template.
+
+# Option defaults
+option.wmclass.default=${package.name}
+option.category.default=Development;Java;IDE;
 
 # Messages
 message.missingdebtools=The dpkg, dpkg-deb and fakeroot commands must be installed.

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/deb/Messages.properties
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/deb/Messages.properties
@@ -15,17 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-option.maintainer.description=Maintainer information as name and email. Mandated in Debian Control file.
-option.description.description=Description of package for Debian Control file. Defaults to information from package name and version.
-option.icon.description=Path to 48x48 png icon as required by xdg specification. Defaults to Apache NetBeans logo.
-option.svg.description=Path to SVG icon. Will only be used if package.deb.icon also set. Defaults to Apache NetBeans logo.
-option.wmclass.description=StartupWMClass to set in .desktop file. Should match the WMClass of the main application window.
-option.category.description=Application category (or categories) to use in the .desktop file.
-option.desktopfilename.description=Optional name for .desktop file (without suffix). Defaults to sanitized package name.
-option.control_template.description=Optional path to custom Debian Control file template.
-option.desktop_template.description=Optional path to custom .desktop file template.
-option.launcher_template.description=Optional path to custom launcher script template.
+# Option file help comments
+option.maintainer.help=Maintainer information as name and email. Mandated in Debian Control file.
+option.description.help=Description of package for Debian Control file. Defaults to information from package name and version.
+option.icon.help=Path to 48x48 png icon as required by xdg specification. Defaults to Apache NetBeans logo.
+option.svg.help=Path to SVG icon. Will only be used if package.deb.icon also set. Defaults to Apache NetBeans logo.
+option.wmclass.help=StartupWMClass to set in .desktop file. Should match the WMClass of the main application window.
+option.category.help=Application category (or categories) to use in the .desktop file.
+option.desktopfilename.help=Optional name for .desktop file (without suffix). Defaults to sanitized package name.
+option.control_template.help=Optional path to custom Debian Control file template.
+option.desktop_template.help=Optional path to custom .desktop file template.
+option.launcher_template.help=Optional path to custom launcher script template.
 
+# Messages
 message.missingdebtools=The dpkg, dpkg-deb and fakeroot commands must be installed.
 message.svgnoicon=The package.deb.icon-svg option is set, but package.deb.icon is not. Using default icons.
 message.nomaintainer=Mandatory maintainer information for Debian control file missing.

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/innosetup/InnoSetup.iss.template
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/innosetup/InnoSetup.iss.template
@@ -14,6 +14,7 @@ Compression=lzma
 SolidCompression=yes
 ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64
+WizardStyle=modern
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/innosetup/Messages.properties
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/innosetup/Messages.properties
@@ -15,12 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Options
-option.innosetuptool.description=Path to an InnoSetup compiler - can be downloaded from https://jrsoftware.org/isinfo.php (or Linux shell script to invoke via wine).
-option.innosetupicon.description=Path to an icon (*.ico) file for shortcut and installer.
-option.innosetuptemplate.description=Optional path to an alternative InnoSetup (*.iss) file template.
-option.innosetupappid.description=ID to uniquely identify application. Defaults to package name.
-option.innosetuplicense.description=Optional path to a license file to be shown during installation (*.txt or *.rtf).
+# Option file help comments
+option.innosetuptool.help=Path to an InnoSetup compiler - can be downloaded from https://jrsoftware.org/isinfo.php (or Linux shell script to invoke via wine).
+option.innosetupicon.help=Path to an icon (*.ico) file for shortcut and installer.
+option.innosetuptemplate.help=Optional path to an alternative InnoSetup (*.iss) file template.
+option.innosetupappid.help=ID to uniquely identify application. Defaults to package name.
+option.innosetuplicense.help=Optional path to a license file to be shown during installation (*.txt or *.rtf).
 
 # Messages
 message.noinnosetuptool=The package.innosetup.tool option must be set.

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/innosetup/Messages.properties
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/innosetup/Messages.properties
@@ -16,11 +16,11 @@
 # under the License.
 
 # Option file help comments
-option.innosetuptool.help=Path to an InnoSetup compiler - can be downloaded from https://jrsoftware.org/isinfo.php (or Linux shell script to invoke via wine).
-option.innosetupicon.help=Path to an icon (*.ico) file for shortcut and installer.
-option.innosetuptemplate.help=Optional path to an alternative InnoSetup (*.iss) file template.
-option.innosetupappid.help=ID to uniquely identify application. Defaults to package name.
-option.innosetuplicense.help=Optional path to a license file to be shown during installation (*.txt or *.rtf).
+option.tool.help=Path to an InnoSetup compiler - can be downloaded from https://jrsoftware.org/isinfo.php (or Linux shell script to invoke via wine).
+option.icon.help=Path to an icon (*.ico) file for shortcut and installer.
+option.template.help=Optional path to an alternative InnoSetup (*.iss) file template.
+option.appid.help=ID to uniquely identify application. Defaults to package name.
+option.license.help=Optional path to a license file to be shown during installation (*.txt or *.rtf).
 
 # Messages
 message.noinnosetuptool=The package.innosetup.tool option must be set.

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/macos/Messages.properties
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/macos/Messages.properties
@@ -15,16 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-option.bundle_id.description=Value for CFBundleIdentifier.
-option.icon.description=Path to icon file (*.icns). Defaults to Apache NetBeans logo.
-option.info_template.description=Optional path to Info.plist template.
-option.launcher_template.description=Optional path to launcher (main.swift) template.
-option.entitlements_template.description=Optional path to codesign entitlements template.
-option.codesign_files.description=Search pattern for native binaries that need to be code signed.
-option.codesign_jars.description=Search pattern for JARs that bundle native binaries that need to be code signed.
-option.codesign_id.description=Code signing identity as passed to Codesign.
-option.pkgbuild_id.description=Installer signing identity as passed to Pkgbuild.
+# Option file help comments
+option.bundle_id.help=Value for CFBundleIdentifier.
+option.icon.help=Path to icon file (*.icns). Defaults to Apache NetBeans logo.
+option.info_template.help=Optional path to Info.plist template.
+option.launcher_template.help=Optional path to launcher (main.swift) template.
+option.entitlements_template.help=Optional path to codesign entitlements template.
+option.codesign_files.help=Search pattern for native binaries that need to be code signed.
+option.codesign_jars.help=Search pattern for JARs that bundle native binaries that need to be code signed.
+option.codesign_id.help=Code signing identity as passed to Codesign.
+option.pkgbuild_id.help=Installer signing identity as passed to Pkgbuild.
 
+# Messages
 message.validatingtools=Validating required tools - {0}
 message.missingtool=Cannot find required tool - {0}
 message.nocodesignid=No codesign ID has been configured. App bundle will be unsigned.

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/rpm/Messages.properties
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/rpm/Messages.properties
@@ -16,10 +16,10 @@
 # under the License.
 
 # Option file help comments
-option.maintainer.help=Maintainer information as name and email. Mandated in spec file.
+option.maintainer.help=Maintainer information as name and email.
 option.vendor.help=Vendor of RPM. Defaults to maintainer.
-option.license.help=Packaged software's license. Defaults to unknown.
-option.group.help=RPM group. Defaults to unknown.
+option.license.help=Application license type (for "License" field in RPM spec file).
+option.group.help=RPM group.
 option.url.help=URL of the software's website. Defaults to unknown.
 option.summary.help=Summary of package for spec file. Defaults to information from package name and version.
 option.description.help=Description of package for spec file. Defaults to information from package name and version.
@@ -31,6 +31,12 @@ option.desktopfilename.help=Optional name for .desktop file (without suffix). De
 option.control_template.help=Optional path to custom spec file template.
 option.desktop_template.help=Optional path to custom .desktop file template.
 option.launcher_template.help=Optional path to custom launcher script template.
+
+# Option defaults
+option.license.default=Apache-2.0
+option.wmclass.default=${package.name}
+option.category.default=Development;Java;IDE;
+option.group.default=Development/Tools/IDE
 
 # Messages
 message.missingrpmtools=The rpm and rpmbuild commands must be installed.

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/rpm/Messages.properties
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/rpm/Messages.properties
@@ -15,22 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-option.maintainer.description=Maintainer information as name and email. Mandated in spec file.
-option.vendor.description=Vendor of RPM. Defaults to maintainer.
-option.license.description=Packaged software's license. Defaults to unknown.
-option.group.description=RPM group. Defaults to unknown.
-option.url.description=URL of the software's website. Defaults to unknown.
-option.summary.description=Summary of package for spec file. Defaults to information from package name and version.
-option.description.description=Description of package for spec file. Defaults to information from package name and version.
-option.icon.description=Path to 48x48 png icon as required by xdg specification. Defaults to Apache NetBeans logo.
-option.svg.description=Path to SVG icon. Will only be used if package.rpm.icon also set. Defaults to Apache NetBeans logo.
-option.wmclass.description=StartupWMClass to set in .desktop file. Should match the WMClass of the main application window.
-option.category.description=Application category (or categories) to use in the .desktop file.
-option.desktopfilename.description=Optional name for .desktop file (without suffix). Defaults to sanitized package name.
-option.control_template.description=Optional path to custom spec file template.
-option.desktop_template.description=Optional path to custom .desktop file template.
-option.launcher_template.description=Optional path to custom launcher script template.
+# Option file help comments
+option.maintainer.help=Maintainer information as name and email. Mandated in spec file.
+option.vendor.help=Vendor of RPM. Defaults to maintainer.
+option.license.help=Packaged software's license. Defaults to unknown.
+option.group.help=RPM group. Defaults to unknown.
+option.url.help=URL of the software's website. Defaults to unknown.
+option.summary.help=Summary of package for spec file. Defaults to information from package name and version.
+option.description.help=Description of package for spec file. Defaults to information from package name and version.
+option.icon.help=Path to 48x48 png icon as required by xdg specification. Defaults to Apache NetBeans logo.
+option.svg.help=Path to SVG icon. Will only be used if package.rpm.icon also set. Defaults to Apache NetBeans logo.
+option.wmclass.help=StartupWMClass to set in .desktop file. Should match the WMClass of the main application window.
+option.category.help=Application category (or categories) to use in the .desktop file.
+option.desktopfilename.help=Optional name for .desktop file (without suffix). Defaults to sanitized package name.
+option.control_template.help=Optional path to custom spec file template.
+option.desktop_template.help=Optional path to custom .desktop file template.
+option.launcher_template.help=Optional path to custom launcher script template.
 
+# Messages
 message.missingrpmtools=The rpm and rpmbuild commands must be installed.
 message.svgnoicon=The package.rpm.icon-svg option is set, but package.rpm.icon is not. Using default icons.
 message.nomaintainer=Mandatory maintainer information for spec file missing.

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/rpm/rpm.spec.template
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/rpm/rpm.spec.template
@@ -20,8 +20,8 @@ AutoReqProv:    no
 ${RPM_DESCRIPTION}
 
 %files
-%{_bindir}/${RPM_EXECNAME}
+%{_bindir}/${RPM_EXEC_NAME}
 %{_libdir}/%{name}/*
-%{_datadir}/applications/%{name}.desktop
+%{_datadir}/applications/${RPM_DESKTOP_NAME}
 %{_datadir}/icons/hicolor/48x48/apps/%{name}.png
 %{_datadir}/icons/hicolor/scalable/apps/%{name}.svg

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/rpm/rpm.spec.template
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/rpm/rpm.spec.template
@@ -1,14 +1,19 @@
-Name:           ${RPM_PACKAGE}
-Version:        ${RPM_VERSION}
-Release:        0
-Summary:        ${RPM_SUMMARY}
-License:        ${RPM_LICENSE}
-Group:          ${RPM_GROUP}
-URL:            ${RPM_URL}
-BuildArch:      ${RPM_ARCH}
-Packager:       ${RPM_MAINTAINER}
-Vendor:         ${RPM_VENDOR}
-Recommends:     ${RPM_RECOMMENDS}
+%define _binaries_in_noarch_packages_terminate_build 0
+%define _unpackaged_files_terminate_build 0
+
+Name: ${RPM_PACKAGE}
+Version: ${RPM_VERSION}
+Release: 0
+BuildArch: ${RPM_ARCH}
+
+${RPM_SUMMARY_LINE}
+${RPM_LICENSE_LINE}
+${RPM_GROUP_LINE}
+${RPM_URL_LINE}
+${RPM_VENDOR_LINE}
+${RPM_MAINTAINER_LINE}
+${RPM_RECOMMENDS_LINE}
+
 AutoReqProv:    no
 
 %description

--- a/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/rpm/rpm.spec.template
+++ b/nbpackage/src/main/resources/org/apache/netbeans/nbpackage/rpm/rpm.spec.template
@@ -20,8 +20,8 @@ AutoReqProv:    no
 ${RPM_DESCRIPTION}
 
 %files
-%{_bindir}/${RPM_EXEC_NAME}
-%{_libdir}/%{name}/*
-%{_datadir}/applications/${RPM_DESKTOP_NAME}
-%{_datadir}/icons/hicolor/48x48/apps/%{name}.png
-%{_datadir}/icons/hicolor/scalable/apps/%{name}.svg
+/usr/bin/${RPM_EXEC_NAME}
+/usr/lib/%{name}
+/usr/share/applications/${RPM_DESKTOP_NAME}
+/usr/share/icons/hicolor/48x48/apps/%{name}.png
+/usr/share/icons/hicolor/scalable/apps/%{name}.svg


### PR DESCRIPTION
Tidy up of options and move to global options where appropriate (publisher, URL, etc.)  Allow missing out `package.` prefix when passing option on command line.

Various fixes for RPM issues including missing options breaking build, noarch build including binaries, file layout mismatch with `/usr/lib64` and `rpm --eval` call failing to report arch.

cc/ @javierllorente can you have a look at some of the RPM updates?