### PR TITLE
Map Apache NetBeans project roles to pp3 roles

### DIFF
--- a/pp3/module/Application/src/Application/Controller/AdminController.php
+++ b/pp3/module/Application/src/Application/Controller/AdminController.php
@@ -229,6 +229,7 @@ class AdminController extends AuthenticatedController {
     }
 
     public function searchUserByEmailAction() {
+        $this->_checkAdminUser();
         /* @var $response Response */
         $response = $this->getResponse();
         $response->getHeaders()->addHeaderLine("Content-Type", "application/json");
@@ -242,7 +243,7 @@ class AdminController extends AuthenticatedController {
                     'email' => $user->getEmail(),
                     'idpProviderId' => $user->getIdpProviderId(),
                     'verifier' => !!$user->isVerifier(),
-                    'admin' => !!$user->isVerifier()
+                    'admin' => !!$user->isAdmin()
                 );
             }
         }

--- a/pp3/module/Application/src/Application/Controller/LoginController.php
+++ b/pp3/module/Application/src/Application/Controller/LoginController.php
@@ -218,8 +218,8 @@ class LoginController extends BaseController {
         $_SESSION['sessionUserEmail'] = $user->getEmail();
         $_SESSION['sessionIdpProviderId'] = $user->getIdpProviderId();
         $_SESSION['sessionUserName'] = $user->getName();
-        $_SESSION['isVerifier'] = $user->isVerifier();
-        $_SESSION['isAdmin'] = $user->isAdmin();
+        $_SESSION['isVerifier'] = $user->isVerifier() || $userinfo['committer'];
+        $_SESSION['isAdmin'] = $user->isAdmin() || $userinfo['pmc'];
 
         return $this->redirect()->toRoute("home");
     }
@@ -301,24 +301,32 @@ class LoginController extends BaseController {
         if(! $json) {
             return null;
         }
-        $userinfo = array();
+        $userinfo = [];
         $userinfo['providerId'] = $providerId;
         if($type == 'github') {
             $userinfo['id'] = "" . $json['id'];
             $userinfo['email'] = "" . $json['email'];
             $userinfo['name'] = "" . $json['name'];
+            $userinfo['pmc'] = false;
+            $userinfo['committer'] = false;
         }  else if ($type == 'google') {
             $userinfo['id'] = "" . $json['sub'];
             $userinfo['email'] = "" . $json['email'];
             $userinfo['name'] = "" . $json['name'];
+            $userinfo['pmc'] = false;
+            $userinfo['committer'] = false;
         } else if ($type == 'amazon') {
             $userinfo['id'] = "" . $json['user_id'];
             $userinfo['email'] = "" . $json['email'];
             $userinfo['name'] = "" . $json['name'];
+            $userinfo['pmc'] = false;
+            $userinfo['committer'] = false;
         } else if ($type == 'apache' && $json['state'] == $state) {
             $userinfo['id'] = "" . $json['uid'];
             $userinfo['email'] = "" . $json['email'];
             $userinfo['name'] = "" . $json['fullname'];
+            $userinfo['pmc'] = is_array($json['pmcs']) && in_array("netbeans", $json['pmcs']);
+            $userinfo['committer'] = is_array($json['projects']) && in_array("netbeans", $json['projects']);
         }
         return $userinfo;
     }

--- a/pp3/module/Application/src/Application/Entity/Base/Verification.php
+++ b/pp3/module/Application/src/Application/Entity/Base/Verification.php
@@ -91,7 +91,10 @@ class Verification {
     public function getPluginVersion() {
         return $this->plugin_version;
     }      
-    
+
+    /**
+     * @return \Application\Entity\VerificationRequest[]
+     */
     public function getVerificationRequests() {
         return $this->verification_requests;
     }

--- a/pp3/module/Application/src/Application/Entity/Base/VerificationRequest.php
+++ b/pp3/module/Application/src/Application/Entity/Base/VerificationRequest.php
@@ -120,7 +120,10 @@ class VerificationRequest {
     public function setVerifierId($vid) {
         $this->verifier_id = $vid;
     }
-    
+
+    /**
+     * @return Verification
+     */
     public function getVerification() {
         return $this->verification;
     }

--- a/pp3/module/Application/src/Application/Repository/VerificationRepository.php
+++ b/pp3/module/Application/src/Application/Repository/VerificationRepository.php
@@ -29,4 +29,24 @@ class VerificationRepository extends DoctrineEntityRepository {
         return $this->entityRepository;
     }
 
+    /**
+     * @param int $id
+     * @return \Application\Entity\Verification
+     */
+    public function find($id) {
+        return parent::find($id);
+    }
+
+    /**
+     * @return \Application\Entity\Verification[]
+     */
+    public function getPendingVerifications() {
+        $queryBuilder = $this->getEntityManager()->createQueryBuilder();
+        $queryBuilder->select('verification')
+        ->from('Application\Entity\Verification', 'verification')
+        ->where('verification.status IN (:status)')
+        ->orderBy('verification.created_at', 'DESC')
+        ->setParameter('status', array(\Application\Entity\Verification::STATUS_REQUESTED, \Application\Entity\Verification::STATUS_PENDING));
+        return $queryBuilder->getQuery()->getResult();
+    }
 }

--- a/pp3/module/Application/src/Application/Repository/VerificationRequestRepository.php
+++ b/pp3/module/Application/src/Application/Repository/VerificationRequestRepository.php
@@ -37,6 +37,10 @@ class VerificationRequestRepository extends DoctrineEntityRepository {
         );
     }
 
+    /**
+     * @param int $verifierId
+     * @return \Application\Entity\VerificationRequest[]
+     */
     public function getVerificationRequestsForVerifier($verifierId) {
         $queryBuilder = $this->getEntityManager()->createQueryBuilder();
         $queryBuilder->select('vrq, verification, verifier, nbVersionPluginVersion, pluginVersion, plugin, nbVersion')

--- a/pp3/module/Application/view/application/verification/list.phtml
+++ b/pp3/module/Application/view/application/verification/list.phtml
@@ -36,10 +36,10 @@
     </thead>
     <tbody>
 <?php
-    foreach ($this->verificationRequests as $vReq) {
-        $verification = $vReq->getVerification();
+    foreach ($this->pendingVerifications as $verification) {
+        $verificationRequest = $this->verificationRequests[$verification->getId()];
         $nbVersion = $verification->getNbVersionPluginVersion()->getNbVersion();
-        $pluginVersion = $vReq->getVerification()->getNbVersionPluginVersion()->getPluginVersion();
+        $pluginVersion = $verification->getNbVersionPluginVersion()->getPluginVersion();
         $plugin = $pluginVersion->getPlugin();
         echo '<tr>
         <td>
@@ -60,14 +60,18 @@
         <td>
             <span class="badge '.$verification->getStatusBadgeClass().'" title="'.$verification->getStatusBadgeTitle().'">'.$verification->getStatusBadgeTitle().'</span>
         </td>
-        <td>    
-            <span class="badge '.$vReq->getVoteBadgeClass().'" title="'.$vReq->getVoteBadgeTitle().'">'.$vReq->getVoteBadgeTitle().'</span>
-        </td>
+        <td>';
+        printf(
+            '<span class="badge %1$s" title="%2$s">%2$s</span>',
+            htmlspecialchars($verificationRequest ? $verificationRequest->getVoteBadgeClass() : ''),
+            htmlspecialchars($verificationRequest ? $verificationRequest->getVoteBadgeTitle() : 'Undecided')
+        );
+        echo '</td>
         <td>
         <div>
-        <a href="'.$this->url('verification', array('action'=>'vote-go'), array('query' => array('id'=>$vReq->getId()))).'" class="btn btn-success" role="button">Go</a>
-        <a href="'.$this->url('verification', array('action'=>'vote-undecided'), array('query' => array('id'=>$vReq->getId()))).'" class="btn btn-default" role="button">Undecided</a>
-        <button type="button" class="btn btn-danger" role="button" data-toggle="modal" data-target="#noGoModal-'.$vReq->getId().'">NoGo</button>
+        <a href="'.$this->url('verification', array('action'=>'vote-go'), array('query' => array('id'=>$verification->getId()))).'" class="btn btn-success" role="button">Go</a>
+        <a href="'.$this->url('verification', array('action'=>'vote-undecided'), array('query' => array('id'=>$verification->getId()))).'" class="btn btn-default" role="button">Undecided</a>
+        <button type="button" class="btn btn-danger" role="button" data-toggle="modal" data-target="#noGoModal-'.$verification->getId().'">NoGo</button>
         
         ';
 
@@ -80,8 +84,8 @@
         }
         echo '
         </div>
-        <div class="modal fade" id="noGoModal-'.$vReq->getId().'" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-            <form action="'.$this->url('verification', array('action'=>'vote-nogo'), array('query' => array('id'=>$vReq->getId()))).'" method="post">
+        <div class="modal fade" id="noGoModal-'.$verification->getId().'" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+            <form action="'.$this->url('verification', array('action'=>'vote-nogo'), array('query' => array('id'=>$verification->getId()))).'" method="post">
                 <div class="modal-dialog" role="document">
                     <div class="modal-content">
                     <div class="modal-header">


### PR DESCRIPTION
There are two project roles in the Apache NetBeans project:

- PMC membership
- Committer membership

These two roles currently give members access to the NetBeans projects. The only part that does not take part in this central roles is the plugin portal. While it is benefical to be able to appoint verifiers independent from the Apache NetBeans problems, it would also be good to give the roles the corresponding rights in the plugin portal.

So this PR introduces the mapping:

PMC membership -> Portal administration
Committer membership -> Verifier

There is still a difference between this automatic mapping and the explicitly registered verifier: E-Mail Requests are only send to explicitly registered verifiers. The mapped reviewers can get a list after logging in and accessing "Verification requests".