### PR TITLE
Fix using old NB16u1 Gradle Tooling after installing NB17 via Snap

### DIFF
--- a/snap-packages/from-source/snapcraft-template.yaml
+++ b/snap-packages/from-source/snapcraft-template.yaml
@@ -73,6 +73,6 @@ parts:
 apps:
   netbeans:
     command-chain:
-      - launchers/nbjavac-cleanup
+      - launchers/userdir-cleanup
     command: netbeans/bin/netbeans
 

--- a/snap-packages/from-zip/snapcraft-template.yaml
+++ b/snap-packages/from-zip/snapcraft-template.yaml
@@ -68,6 +68,6 @@ parts:
 apps:
   netbeans:
     command-chain:
-      - launchers/nbjavac-cleanup
+      - launchers/userdir-cleanup
     command: netbeans/bin/netbeans
 

--- a/snap-packages/launchers/userdir-cleanup
+++ b/snap-packages/launchers/userdir-cleanup
@@ -4,5 +4,7 @@
 find ${SNAP_USER_DATA} -name '*nbjavac.*' -delete || true
 find ${SNAP_USER_DATA} -name '*nbjavac-*' -delete || true
 
+# Remove NetBeans Gradle Tooling if that was patched between releases.
+find ${SNAP_USER_DATA} -name netbeans-gradle-tooling.jar -delete || true
 exec $@
 


### PR DESCRIPTION
Fixes: https://github.com/apache/netbeans/issues/5610

I need to re-create the Snap package with this script.

NetBeans is smart enough to use the correct module on upgrade since that's based by the version numbers. But non-module jars seems to have a priority loading form userdir instead from the installed location. May need to think something more sophisticated than this, however this would be good enough.
