### PR TITLE
Enable arm64 Architecture on Snap from zip Packages

### DIFF
--- a/snap-packages/from-zip/build.xml
+++ b/snap-packages/from-zip/build.xml
@@ -29,8 +29,8 @@
         <format property="build.date" pattern="yyyyMMdd"/>
     </tstamp>        
     
-    <available property="has.dev.snap" file="${dev.dir}/netbeans-dev_${build.date}_amd64.snap"/>
-    <available property="has.rel.snap" file="${rel.dir}/netbeans_${release.version}_amd64.snap"/>
+    <available property="has.dev.snap" file="${dev.dir}/netbeans-dev_${build.date}_multi.snap"/>
+    <available property="has.rel.snap" file="${rel.dir}/netbeans_${release.version}_multi.snap"/>
 
     <target name="usage">
         <echo><![CDATA[
@@ -160,7 +160,7 @@
     <target name="upload-dev" if="${has.dev.snap}" >
         <exec executable="snapcraft" dir="${dev.dir}">
             <arg value="upload"/>
-            <arg value="netbeans-dev_${build.date}_amd64.snap"/>
+            <arg value="netbeans-dev_${build.date}_multi.snap"/>
             <arg value="--release"/>
             <arg value="edge"/>
         </exec>
@@ -169,7 +169,7 @@
     <target name="upload-rel" if="${has.rel.snap}" >
         <exec executable="snapcraft" dir="${rel.dir}">
             <arg value="upload"/>
-            <arg value="netbeans_${release.version}_amd64.snap"/>
+            <arg value="netbeans_${release.version}_multi.snap"/>
             <arg value="--release"/>
             <arg value="edge"/>
         </exec>

--- a/snap-packages/from-zip/build.xml
+++ b/snap-packages/from-zip/build.xml
@@ -125,14 +125,14 @@
 
     <target name="snap-dev" depends="prepare-dev" unless="${has.dev.snap}">
         <exec executable="snapcraft" dir="${dev.dir}">
-            <arg value="snap"/>
+            <arg value="pack"/>
             <arg value="--use-lxd"/>
         </exec>
     </target>
     
     <target name="snap-rel" depends="prepare-rel" unless="${has.rel.snap}">
         <exec executable="snapcraft" dir="${rel.dir}">
-            <arg value="snap"/>
+            <arg value="pack"/>
             <arg value="--use-lxd"/>
         </exec>
     </target>

--- a/snap-packages/from-zip/snapcraft-template.yaml
+++ b/snap-packages/from-zip/snapcraft-template.yaml
@@ -25,13 +25,17 @@ description: |@SNAP_DISCLAIMER@
   It is free and open source and has a large community of users and developers
   around the world.
   
-  It requires Java 8 or later Java Development Kit installed.
+  It requires Java 11 or later Java Development Kit installed.
 
 icon: snap/gui/frame512.png
 confinement: classic
 grade: @SNAP_GRADE@
-base: core20
-architectures: [ amd64, arm64, armhf, i386 ]
+base: core22
+architectures: 
+  - build-on: [ amd64 ]
+    build-for: [ amd64 ]
+  - build-on: [ amd64 ]
+    build-for: [ arm64 ]
 compression: lzo
 assumes:
   - command-chain
@@ -44,8 +48,6 @@ parts:
     build-attributes: [ no-patchelf ]
     plugin: dump
     source: @SNAP_SOURCE@
-    filesets:
-        netbeans: [ netbeans/*, -netbeans/*.built ]
     override-build: |
         mv netbeans $SNAPCRAFT_PART_INSTALL/netbeans
         # Make the default cache and data directory relative to Snap user directory
@@ -57,7 +59,9 @@ parts:
         chmod a+r $SNAPCRAFT_PART_INSTALL/netbeans/etc/netbeans.conf
         find $SNAPCRAFT_PART_INSTALL/netbeans -type f -name *.sh -exec chmod a+rx {} \;
     stage:
-        - $netbeans
+        - netbeans/*
+        - -netbeans/*.built
+        - -netbeans/extra
 
   launchers:
     source: snap/local/launchers

--- a/snap-packages/from-zip/snapcraft-template.yaml
+++ b/snap-packages/from-zip/snapcraft-template.yaml
@@ -31,7 +31,7 @@ icon: snap/gui/frame512.png
 confinement: classic
 grade: @SNAP_GRADE@
 base: core20
-architectures: [ amd64 ]
+architectures: [ amd64, arm64, armhf, i386 ]
 compression: lzo
 assumes:
   - command-chain


### PR DESCRIPTION
Based on John Neffenger idea. As the Snap package us based on the zip distribution, there is no need to have cross compiler, target hardware to create a multi arch package. so this one is as cheap as the amd64 package before.