### PR TITLE
Use plain string replacement for email preparation

### DIFF
--- a/pp3/module/Application/src/Application/Controller/AdminController.php
+++ b/pp3/module/Application/src/Application/Controller/AdminController.php
@@ -446,11 +446,12 @@ Apache NetBeans Plugin Portal Administrator
                 $mail->setFrom('noreply@netbeans.apache.org', 'NetBeans webmaster');
                 $mail->setSubject($subject);
                 $mail->getHeaders()->addHeader(ContentType::fromString('Content-Type: text/html; charset=utf-8'));
-                $mail->setBody(sprintf($emailText,
-                                htmlspecialchars($entry['name']),
-                                htmlspecialchars($this->getHomeUrl()),
-                                $list
-                ));
+                $htmlBody = str_replace(
+                    ['%1$s', '%2$s', '%3$s'],
+                    [htmlspecialchars($entry['name']), htmlspecialchars($this->getHomeUrl()), $list],
+                    $emailText
+                );
+                $mail->setBody($htmlBody);
                 $mail->addTo($entry['email']);
                 $transport->send($mail);
             }


### PR DESCRIPTION
The usage of sprintf makes it vulnerable to improperly formatted input textes. The problem was observed when a "mailto" link was integrated into the email text, which not only held an email, but also subject and body text.