### PR TITLE
Fixes

### DIFF
--- a/pp3/module/Application/view/application/verification/list.phtml
+++ b/pp3/module/Application/view/application/verification/list.phtml
@@ -37,7 +37,7 @@
     <tbody>
 <?php
     foreach ($this->pendingVerifications as $verification) {
-        $verificationRequest = $this->verificationRequests[$verification->getId()];
+        $verificationRequest = array_key_exists($verification->getId(), $this->verificationRequests) ? $this->verificationRequests[$verification->getId()] : false;
         $nbVersion = $verification->getNbVersionPluginVersion()->getNbVersion();
         $pluginVersion = $verification->getNbVersionPluginVersion()->getPluginVersion();
         $plugin = $pluginVersion->getPlugin();

--- a/pp3/public/.htaccess
+++ b/pp3/public/.htaccess
@@ -16,6 +16,11 @@
 # under the License.
 
 RewriteEngine On
+
+# Disabling HTTP access to Plugin Portal 3.0 by auto-redirect to HTTPS protocol
+RewriteCond %{HTTPS} off
+RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
 # The following rule tells Apache that if the requested filename
 # exists, simply serve it.
 RewriteCond %{REQUEST_FILENAME} -s [OR]


### PR DESCRIPTION
- Disabling HTTP access to Plugin Portal 3.0 by auto-redirect to HTTPS protocol
- Prevent "Undefined index" notice

Fixes were already in production, but never committed to VCS