### PR TITLE
Fix snap audit fail due to duplicate assumes

### DIFF
--- a/snap-packages/from-source/snapcraft-template.yaml
+++ b/snap-packages/from-source/snapcraft-template.yaml
@@ -25,7 +25,7 @@ description: |@SNAP_DISCLAIMER@
   It is free and open source and has a large community of users and developers
   around the world.
   
-  It requires Java 8 or later Java Development Kit installed.
+  It requires Java 17 or later Java Development Kit installed.
 
 icon: snap/gui/frame512.png
 confinement: classic
@@ -33,8 +33,6 @@ grade: @SNAP_GRADE@
 base: core22
 architectures: [ amd64 ]
 compression: lzo
-assumes:
-  - command-chain
 version: "@SNAP_VERSION@"
 
 parts:

--- a/snap-packages/from-zip/build.xml
+++ b/snap-packages/from-zip/build.xml
@@ -37,7 +37,7 @@
         
         Creating a Release:
         
-          ant -Dreleaase.version=<version> -Drelease.binary=<URL> snap-rel
+          ant -Drelease.version=<version> -Drelease.binary=<URL> snap-rel
      ]]></echo>
     </target>
 

--- a/snap-packages/from-zip/snapcraft-template.yaml
+++ b/snap-packages/from-zip/snapcraft-template.yaml
@@ -25,7 +25,7 @@ description: |@SNAP_DISCLAIMER@
   It is free and open source and has a large community of users and developers
   around the world.
   
-  It requires Java 11 or later Java Development Kit installed.
+  It requires Java 17 or later Java Development Kit installed.
 
 icon: snap/gui/frame512.png
 confinement: classic
@@ -37,8 +37,6 @@ architectures:
   - build-on: [ amd64 ]
     build-for: [ arm64 ]
 compression: lzo
-assumes:
-  - command-chain
 
 version: "@SNAP_VERSION@"
 


### PR DESCRIPTION
It seems snapcraft adds `command-chain` feature flag automatically to the snap, as this `23-rc2` validation failed.
It took some time to get my LXD fixed, to test if the validation would fail without specifying that flag.

So either this is a fix for that or Canonical fixed their validation and/or Snapcraft, I do not really know.

The `23-rc2` built with this code passed the validation though.