### PR TITLE
Snap: Patch custom netbeans.conf in existing userdir

### DIFF
--- a/snap-packages/from-source/snapcraft-template.yaml
+++ b/snap-packages/from-source/snapcraft-template.yaml
@@ -74,5 +74,6 @@ apps:
   netbeans:
     command-chain:
       - launchers/userdir-cleanup
+      - launchers/patch-netbeans-conf
     command: netbeans/bin/netbeans
 

--- a/snap-packages/from-zip/snapcraft-template.yaml
+++ b/snap-packages/from-zip/snapcraft-template.yaml
@@ -71,5 +71,6 @@ apps:
   netbeans:
     command-chain:
       - launchers/userdir-cleanup
+      - launchers/patch-netbeans-conf
     command: netbeans/bin/netbeans
 

--- a/snap-packages/launchers/patch-netbeans-conf
+++ b/snap-packages/launchers/patch-netbeans-conf
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# If the user has a custom netbeans.conf. Disable Java Security Manager as of NetBeans 25
+if [ -f "$SNAP_USER_DATA/etc/netbeans.conf" ]; then
+    if ! grep -q '^netbeans_default_options=".*-J-Djava.lang.Runtime.level=' $SNAP_USER_DATA/etc/netbeans.conf ; then
+        sed -i 's/netbeans_default_options="/netbeans_default_options="-J-Djava.lang.Runtime.level=FINE /' $SNAP_USER_DATA/etc/netbeans.conf
+    fi
+    if ! grep -q '^netbeans_default_options=".*-J-DTopSecurityManager.disable=' $SNAP_USER_DATA/etc/netbeans.conf ; then
+        sed -i 's/netbeans_default_options="/netbeans_default_options="-J-DTopSecurityManager.disable=true /' $SNAP_USER_DATA/etc/netbeans.conf
+    fi
+fi
+
+exec $@


### PR DESCRIPTION
Small script makes Snap users who override their own `netbeans.conf` a seamless switch from NetBeans 24 to NetBeans 25