### PR TITLE
Remove application version from Desktop icons installed from Snap

### DIFF
--- a/snap-packages/from-source/build.xml
+++ b/snap-packages/from-source/build.xml
@@ -74,7 +74,8 @@
         <copy file="netbeans-template.desktop" tofile="${dev.dir}/snap/gui/netbeans.desktop" overwrite="true">
             <filterchain>
                 <replacetokens>
-                    <token key="DESKTOP_VERSION" value="(development)"/>
+                    <token key="DESKTOP_APP_NAME" value="Apache NetBeans (dev)"/>
+                    <token key="DESKTOP_VERSION" value="DEV ${build.date}"/>
                     <token key="DESKTOP_EXEC" value="netbeans-dev.netbeans"/>
                 </replacetokens>
             </filterchain>
@@ -112,6 +113,7 @@
         <copy file="netbeans-template.desktop" tofile="${rel.dir}/snap/gui/netbeans.desktop" overwrite="true">
             <filterchain>
                 <replacetokens>
+                    <token key="DESKTOP_APP_NAME" value="Apache NetBeans"/>
                     <token key="DESKTOP_VERSION" value="${release.version}"/>
                     <token key="DESKTOP_EXEC" value="netbeans"/>
                 </replacetokens>

--- a/snap-packages/from-source/netbeans-template.desktop
+++ b/snap-packages/from-source/netbeans-template.desktop
@@ -17,7 +17,7 @@
 [Desktop Entry]
 Type=Application
 Encoding=UTF-8
-Name=Apache NetBeans @DESKTOP_VERSION@
+Name=@DESKTOP_APP_NAME@
 Comment=Apache NetBeans, The Smarter Way to Code
 Exec=@DESKTOP_EXEC@ %F
 Categories=Development;IDE

--- a/snap-packages/from-zip/build.xml
+++ b/snap-packages/from-zip/build.xml
@@ -79,7 +79,8 @@
         <copy file="netbeans-template.desktop" tofile="${dev.dir}/snap/gui/netbeans.desktop" overwrite="true">
             <filterchain>
                 <replacetokens>
-                    <token key="DESKTOP_VERSION" value="(development)"/>
+                    <token key="DESKTOP_APP_NAME" value="Apache NetBeans (dev)"/>
+                    <token key="DESKTOP_VERSION" value="DEV ${build.date}"/>
                     <token key="DESKTOP_EXEC" value="netbeans-dev.netbeans"/>
                 </replacetokens>
             </filterchain>
@@ -116,6 +117,7 @@
         <copy file="netbeans-template.desktop" tofile="${rel.dir}/snap/gui/netbeans.desktop" overwrite="true">
             <filterchain>
                 <replacetokens>
+                    <token key="DESKTOP_APP_NAME" value="Apache NetBeans"/>
                     <token key="DESKTOP_VERSION" value="${release.version}"/>
                     <token key="DESKTOP_EXEC" value="netbeans"/>
                 </replacetokens>

--- a/snap-packages/from-zip/netbeans-template.desktop
+++ b/snap-packages/from-zip/netbeans-template.desktop
@@ -17,7 +17,7 @@
 [Desktop Entry]
 Type=Application
 Encoding=UTF-8
-Name=Apache NetBeans @DESKTOP_VERSION@
+Name=@DESKTOP_APP_NAME@
 Comment=Apache NetBeans, The Smarter Way to Code
 Exec=@DESKTOP_EXEC@ %F
 Categories=Development;IDE


### PR DESCRIPTION
My initial intent was remove the version number from the name of the Snap installed application.

With 4 releases a year, version numbers are getting less and less important and people around 20 will start to loose the track. That's especially true with server initiated auto-updates of Snaps.

![image](https://github.com/user-attachments/assets/21ba942f-46b3-4601-8b3a-71496df1a3d2)

I've made a test to remove the `Apache` from the name, that's the dev version on the image. That's teh most simple one, though I did not feel that right.