### PR TITLE
PP3: Sort plugin versions descending

### DIFF
--- a/pp3/module/Application/src/Application/Entity/Plugin.php
+++ b/pp3/module/Application/src/Application/Entity/Plugin.php
@@ -203,4 +203,17 @@ class Plugin extends Base\Plugin {
         return $url;
     }
 
+    public function getVersionsSorted($desc = true) {
+        $result = [];
+        foreach($this->getVersions() as $version) {
+            $result[] = $version;
+        }
+
+        if($desc) {
+            usort($result, fn($a, $b) => -1 * PluginVersion::compare($a, $b));
+        } else {
+            usort($result, fn($a, $b) => PluginVersion::compare($a, $b));
+        }
+        return $result;
+    }
 }

--- a/pp3/module/Application/src/Application/Entity/PluginVersion.php
+++ b/pp3/module/Application/src/Application/Entity/PluginVersion.php
@@ -75,4 +75,36 @@ class PluginVersion extends Base\PluginVersion {
         }
         throw new \Exception('Nbm nor jar binary found on '.$baseUrl);
     }
+
+    /**
+     * @param PluginVersion $a
+     * @param PluginVersion $b
+     * @return int
+     */
+    static function compare($a, $b) {
+        $sA = [0];
+        $sB = [0];
+        $matchesA = null;
+        if (preg_match("/^(\\d+\\.)*(\\d+)/", $a->getVersion(), $matchesA)) {
+            $versionString = $matchesA[0];
+            $sA = array_map(function ($v) {
+                return (int) $v;
+            }, explode(".", $versionString));
+        }
+        $matchesB = null;
+        if (preg_match("/^(\\d+\\.)*(\\d+)/", $b->getVersion(), $matchesB)) {
+            $versionString = $matchesB[0];
+            $sB = array_map(function ($v) {
+                return (int) $v;
+            }, explode(".", $versionString));
+        }
+        $compLength = min(count($sA), count($sB));
+        for ($i = 0; $i < $compLength; $i++) {
+            $res = $sA[$i] - $sB[$i];
+            if ($res != 0) {
+                return $res;
+            }
+        }
+        return strcmp($a->getVersion(), $b->getVersion());
+    }
 }

--- a/pp3/module/Application/view/application/admin/_plugin-listrow.phtml
+++ b/pp3/module/Application/view/application/admin/_plugin-listrow.phtml
@@ -77,7 +77,7 @@ echo '</p>
         </thead>
         <tbody>';
 
-foreach ($plugin->getVersions() as $version) {
+foreach ($plugin->getVersionsSorted() as $version) {
     /* @var $version Application\Entity\PluginVersion */
     printf('<tr>
         <td><span class="badge %s">%s%s</span></td>

--- a/pp3/module/Application/view/application/admin/_pluginRowItem.phtml
+++ b/pp3/module/Application/view/application/admin/_pluginRowItem.phtml
@@ -20,7 +20,7 @@
 ?>
 <?php
 $versionBadges = array();
-foreach ($plugin->getVersions() as $version) {
+foreach ($plugin->getVersionsSorted() as $version) {
     $versionBadges[]='<span class="badge">'.$version->getVersion().'</span>';
 }
 

--- a/pp3/module/Application/view/application/admin/approve.phtml
+++ b/pp3/module/Application/view/application/admin/approve.phtml
@@ -34,8 +34,9 @@
     <tbody>
 <?php
     foreach ($this->plugins as $plugin) {
+        /* @var $plugin Application\Entity\Plugin */
         $versionBadges = array();
-        foreach ($plugin->getVersions() as $version) {
+        foreach ($plugin->getVersionsSorted() as $version) {
             $versionBadges[]='<span class="badge">'.$version->getVersion().'</span>';
         }
         echo '<tr>

--- a/pp3/module/Application/view/application/index/catalogue.phtml
+++ b/pp3/module/Application/view/application/index/catalogue.phtml
@@ -63,7 +63,7 @@ if ($plugin) {
         </thead>
         <tbody>
         ';
-        foreach ($plugin->getVersions() as $version) {
+        foreach ($plugin->getVersionsSorted() as $version) {
             echo '<tr><td><span class="badge">'.$version->getVersion().'</span></td><td>';
             foreach ($version->getNbVersionsPluginVersions() as $nbvPv) {
                 $downloadUrl = './download/'.$version->getId().'/'.htmlspecialchars($version->getArtifactFilename());

--- a/pp3/module/Application/view/application/index/index.phtml
+++ b/pp3/module/Application/view/application/index/index.phtml
@@ -125,7 +125,7 @@
         }
 
         $versionBadges = array();
-        foreach ($plugin->getVersions() as $version) {
+        foreach ($plugin->getVersionsSorted() as $version) {
           foreach ($version->getNbVersionsPluginVersions() as $nbvPv) {
             $verif = $nbvPv->getVerification();
             if ($verif && $verif->isVerified()) {

--- a/pp3/module/Application/view/application/plugin/_plugin-listrow.phtml
+++ b/pp3/module/Application/view/application/plugin/_plugin-listrow.phtml
@@ -19,7 +19,7 @@
  */
 ?>
 <?php
-$pluugin = $this->plugin;
+/* @var $plugin Application\Entity\Plugin */
 echo '<tr>
 <td style="text-align: center;"><h4><i class="fas '.$plugin->getStatusIconClass().'" title="'.$plugin->getStatusTitle().'"></i></h4></td>
 <td>
@@ -66,7 +66,7 @@ echo '</p>
         </thead>
         <tbody>';
 
-foreach ($plugin->getVersions() as $version) {
+foreach ($plugin->getVersionsSorted() as $version) {
     /* @var $version Application\Entity\PluginVersion */
     printf('<tr>
         <td><span class="badge %s">%s%s</span></td>


### PR DESCRIPTION
The plugin versions are currently listed in DB order/unordered. To improve usability the versions should be ordered in descending order. This assumes, that the most recent version is the most relevant one.

It is assumed, that the versions all start with a dotted version number "1.2.3-RC1" for example.

Closes: https://github.com/apache/netbeans/issues/9391